### PR TITLE
GH-17: Remove bd/beads/cupboard references

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -33,7 +33,7 @@ generation:
     cleanup_dirs: []
 cobbler:
     dir: .cobbler/
-    beads_dir: .beads/
+    beads_dir: ""
     max_stitch_issues: 0
     max_stitch_issues_per_cycle: 10
     max_measure_issues: 1

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -220,9 +220,9 @@ document_types:
       (major.minor). Minor releases validate completed major releases.
 
 naming_conventions:
-  prd: "prd[NNN]-[feature-name].yaml (e.g., prd001-cupboard-core.yaml)"
-  use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel01.0-uc001-cupboard-lifecycle.yaml)"
-  test_suite: "test-[use-case-id].yaml (e.g., test-rel01.0-uc001-cupboard-lifecycle.yaml)"
+  prd: "prd[NNN]-[feature-name].yaml (e.g., prd001-hello-world-binary.yaml)"
+  use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel02.0-uc001-build-hello-world.yaml)"
+  test_suite: "test-[use-case-id].yaml (e.g., test-rel02.0-uc001-build-hello-world.yaml)"
   engineering_guideline: "eng[NN]-[short-name].yaml (e.g., eng01-git-integration.yaml)"
   architecture: "ARCHITECTURE.yaml"
   vision: "VISION.yaml"

--- a/docs/constitutions/execution.yaml
+++ b/docs/constitutions/execution.yaml
@@ -100,7 +100,7 @@ coding_standards:
     - "JSON handling: encoding/json (stdlib)"
 
   naming_conventions:
-    exported: PascalCase (e.g., CupboardConfig)
+    exported: PascalCase (e.g., ProjectConfig)
     unexported: camelCase (e.g., cobblerConfig)
     cli_flags: kebab-case (e.g., --silence-agent)
     binary_constants: "bin prefix + PascalCase (e.g., binGit, binClaude)"
@@ -155,7 +155,7 @@ session_completion:
     - Do NOT run any git commands (add, commit, status, init, rm .git)
     - Git is managed externally by the orchestrator
     - Your job is to write code and verify it works
-    - Do NOT use bd or cupboard commands
+    - Do NOT interact with the issue tracker directly; GitHub Issues are managed by the orchestrator
 
 technology:
   primary_language: Go
@@ -163,7 +163,7 @@ technology:
   cli_framework: cobra
   build_system: mage
   yaml_library: gopkg.in/yaml.v3
-  issue_tracker: cupboard (migrating from beads)
+  issue_tracker: github-issues
 
 git_conventions:
   note: Git is managed externally. Do NOT run any git commands.
@@ -198,8 +198,8 @@ sections:
     title: Technology Stack
     content: |
       The project uses Go with mage for build automation, cobra for CLI, viper
-      for configuration, yaml.v3 for YAML parsing, and cupboard (migrating from
-      beads) for issue tracking.
+      for configuration, yaml.v3 for YAML parsing, and GitHub Issues for task
+      tracking.
   - tag: git_conventions
     title: Git Conventions
     content: |

--- a/docs/constitutions/go-style.yaml
+++ b/docs/constitutions/go-style.yaml
@@ -169,7 +169,7 @@ struct_embedding: |
   CLI flags. Do not duplicate fields across sibling structs.
 
 naming_conventions:
-  - "Exported types and functions: PascalCase (e.g., CupboardConfig)"
+  - "Exported types and functions: PascalCase (e.g., ProjectConfig)"
   - "Unexported types and functions: camelCase (e.g., cobblerConfig)"
   - "CLI flags: kebab-case (e.g., --silence-agent)"
   - "Constants for binaries: bin prefix + PascalCase (e.g., binGit, binClaude)"

--- a/docs/constitutions/planning.yaml
+++ b/docs/constitutions/planning.yaml
@@ -206,7 +206,7 @@ example_documentation_issue: |
 
   required_reading:
     - docs/ARCHITECTURE.yaml (components section)
-    - docs/specs/product-requirements/prd001-cupboard-core.yaml
+    - docs/specs/product-requirements/prd001-hello-world-binary.yaml
 
   files:
     - path: docs/specs/product-requirements/prd-feature-name.yaml
@@ -232,7 +232,7 @@ example_code_issue: |
 
   required_reading:
     - docs/specs/product-requirements/prd003-crumbs-interface.yaml
-    - pkg/types/cupboard.go
+    - cmd/sdd-hello-world/main.go
 
   files:
     - path: pkg/types/crumb.go
@@ -255,7 +255,7 @@ example_code_issue: |
 
   design_decisions:
     - id: D1
-      text: Use table accessor pattern from prd001-cupboard-core
+      text: Follow binary structure from prd001-hello-world-binary
     - id: D2
       text: Filter as map[string]any per PRD
 

--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -74,7 +74,7 @@ output_format: |
 
         design_decisions:
           - id: D1
-            text: Use table accessor pattern from prd001-cupboard-core
+            text: Follow binary structure from prd001-hello-world-binary
           - id: D2
             text: "Keep implementation in internal/, not pkg/"
 

--- a/docs/prompts/stitch.yaml
+++ b/docs/prompts/stitch.yaml
@@ -19,7 +19,7 @@ constraints: |
   - Do NOT read files already provided in project_context. They are already inline above.
   - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands.
   - Do NOT modify files outside the Files to Create/Modify list unless a requirement explicitly demands it.
-  - Do NOT use bd or cupboard commands. Task tracking is handled externally.
+  - Do NOT interact with the issue tracker directly. Task tracking is handled externally via GitHub Issues.
   - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or PRDs.
   - Do NOT add features, refactoring, or improvements beyond what the requirements specify.
   - Do NOT run any git commands. No git add, git commit, git init, git status, rm .git, or any other git operation. Git is managed externally by the orchestrator. Just write code and verify it compiles and passes tests.


### PR DESCRIPTION
## Summary

Remove all legacy issue tracker references (bd, beads, cupboard) from configuration, constitutions, and prompts. Replace with GitHub Issues references and update naming examples to use hello-world-specific terms.

## Changes

- Cleared `beads_dir` in `configuration.yaml`
- Reworded stitch/measure prompt constraints to reference GitHub Issues
- Updated `execution.yaml`: issue_tracker, naming examples, critical_rules, technology section summary
- Updated `design.yaml` and `planning.yaml` naming examples from cupboard to hello-world
- Updated `go-style.yaml` naming example from CupboardConfig to ProjectConfig

## Test plan

- [x] `mage analyze` passes
- [x] No bd/beads/cupboard references remain in any YAML file (except the schema field name `beads_dir`)

Closes #17