### PR TITLE
GH-27: Set cobbler.mode: cli in configuration.yaml

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -32,6 +32,7 @@ generation:
     branch: ""
     cleanup_dirs: []
 cobbler:
+    mode: cli
     dir: .cobbler/
     beads_dir: ""
     max_stitch_issues: 0


### PR DESCRIPTION
## Summary

Sets `cobbler.mode: cli` in `configuration.yaml` so the execution mode no longer defaults to `podman`, which fails without a container runtime (cobbler-scaffold GH-833).

## Changes

- Added `mode: cli` to the `cobbler:` section in `configuration.yaml`

## Test plan

- [x] `mage analyze` passes

Closes #27