### PR TITLE
GH-26: Upgrade to latest cobbler-scaffold

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -32,7 +32,7 @@ generation:
     branch: ""
     cleanup_dirs: []
 cobbler:
-    mode: cli
+    mode: sdk
     dir: .cobbler/
     beads_dir: ""
     max_stitch_issues: 0

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.3
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.7
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.3 h1:WfM97Ui4jXWK1FCcoqOhBgdKoCMGX39xQAMA4/+KMa0=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.3/go.mod h1:xFuIzON+/BqFbFCdpI26RqigNcaLuWACZIj7wT6T2QI=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.7 h1:bHaNjLZkSiLlJDSWfo3Nc/CdtfRF7eQsTUvYhF/pBZE=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.7/go.mod h1:YVc2XV4LdKH9+yIdAJlsYdOXxOI/rEs+bP0buLyjVXI=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260306.3 to v0.20260306.7 and switches cobbler.mode from cli to sdk for direct API-based execution.

## Changes

- Updated `magefiles/go.mod` to cobbler-scaffold v0.20260306.7
- Refreshed `magefiles/go.sum`
- Changed `cobbler.mode` from `cli` to `sdk` in `configuration.yaml`

## Test plan

- [x] `mage analyze` passes

Closes #26