### PR TITLE
GH-31: Fix .gitignore blocking cmd/sdd-hello-world/ source directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 bin/
-sdd-hello-world
+/sdd-hello-world
 .claude/


### PR DESCRIPTION
## Summary

Fixes the `.gitignore` pattern `sdd-hello-world` that was matching at all directory levels, preventing `cmd/sdd-hello-world/` source files from being staged. Changed to `/sdd-hello-world` to restrict the match to the repo root binary only.

## Changes

- Changed `sdd-hello-world` to `/sdd-hello-world` in `.gitignore`

## Test plan

- [x] Pattern now only matches repo-root binary, not `cmd/sdd-hello-world/`

Closes #31