### PR TITLE
GH-30: Upgrade to latest cobbler-scaffold

### DIFF
--- a/docs/specs/product-requirements/prd001-hello-world-binary.yaml
+++ b/docs/specs/product-requirements/prd001-hello-world-binary.yaml
@@ -44,7 +44,15 @@ non_goals:
   - Writing tests within this project (cobbler-scaffold's E2E suite provides coverage)
 
 acceptance_criteria:
-  - go build ./cmd/sdd-hello-world succeeds with exit code 0.
-  - Running the compiled binary produces exactly "Hello, World!\n" on stdout and exits with code 0.
-  - cmd/sdd-hello-world/main.go exists with a main function.
-  - cmd/sdd-hello-world/version.go exists with a Version constant.
+  - id: AC1
+    criterion: go build ./cmd/sdd-hello-world succeeds with exit code 0.
+    traces: [R1.1, R1.2, R1.3]
+  - id: AC2
+    criterion: Running the compiled binary produces exactly "Hello, World!\n" on stdout and exits with code 0.
+    traces: [R2.1, R2.2, R2.3]
+  - id: AC3
+    criterion: cmd/sdd-hello-world/main.go exists with a main function.
+    traces: [R1.1]
+  - id: AC4
+    criterion: cmd/sdd-hello-world/version.go exists with a Version constant.
+    traces: [R1.2]

--- a/docs/specs/use-cases/rel02.0-uc001-build-hello-world.yaml
+++ b/docs/specs/use-cases/rel02.0-uc001-build-hello-world.yaml
@@ -46,11 +46,14 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    text: go build ./cmd/sdd-hello-world exits with code 0.
+    criterion: go build ./cmd/sdd-hello-world exits with code 0.
+    traces: [AC1]
   - id: S2
-    text: The binary prints "Hello, World!\n" to stdout.
+    criterion: The binary prints "Hello, World!\n" to stdout.
+    traces: [AC2]
   - id: S3
-    text: The binary exits with code 0.
+    criterion: The binary exits with code 0.
+    traces: [AC2]
 
 out_of_scope:
   - Testing with command-line arguments or flags

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.7
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.7 h1:bHaNjLZkSiLlJDSWfo3Nc/CdtfRF7eQsTUvYhF/pBZE=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.7/go.mod h1:YVc2XV4LdKH9+yIdAJlsYdOXxOI/rEs+bP0buLyjVXI=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2 h1:tl6q5Uww1wUkH5t/CaUcmrFSgC6DcWKpnOU+xEkQW9E=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260306.7 to v0.20260308.2. Fixes PRD acceptance criteria and UC success criteria to use the structured id/criterion/traces format required by the new schema validation.

## Changes

- Updated `magefiles/go.mod` to cobbler-scaffold v0.20260308.2
- Refreshed `magefiles/go.sum`
- Converted PRD `acceptance_criteria` from plain strings to structured `{id, criterion, traces}` objects
- Converted UC `success_criteria` from `{id, text}` to `{id, criterion, traces}` objects

## Test plan

- [x] `mage analyze` passes (0 schema errors)

Closes #30