### PR TITLE
GH-33: Tighten UC S-items and strengthen F-item rationale

### DIFF
--- a/docs/specs/use-cases/rel02.0-uc001-build-hello-world.yaml
+++ b/docs/specs/use-cases/rel02.0-uc001-build-hello-world.yaml
@@ -20,13 +20,13 @@ flow:
   - id: F1
     text: Run go build ./cmd/sdd-hello-world to compile the binary.
   - id: F2
-    text: Verify the build succeeds with exit code 0.
+    text: Verify the build succeeds with exit code 0 (gates F3; a failed build produces no binary to run).
   - id: F3
-    text: Run the compiled binary.
+    text: Run the compiled binary (requires artifact from F1 and success confirmation from F2).
   - id: F4
-    text: Capture stdout and the exit code.
+    text: Capture stdout and the exit code (must happen during F3 execution to avoid lost output).
   - id: F5
-    text: Verify stdout contains exactly "Hello, World!\n" and exit code is 0.
+    text: Verify stdout contains exactly "Hello, World!\n" and exit code is 0 (requires captured values from F4).
 
 touchpoints:
   - id: T1
@@ -46,14 +46,12 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: go build ./cmd/sdd-hello-world exits with code 0.
-    traces: [AC1]
-  - id: S2
-    criterion: The binary prints "Hello, World!\n" to stdout.
-    traces: [AC2]
-  - id: S3
-    criterion: The binary exits with code 0.
-    traces: [AC2]
+    criterion: |
+      The end-to-end sequence (build, run, capture, verify) completes: go build
+      exits 0, the resulting binary prints exactly "Hello, World!\n" to stdout,
+      and the binary exits 0. This exercises AC1 and AC2 together as an
+      integration check that the generated source compiles and behaves correctly.
+    traces: [AC1, AC2]
 
 out_of_scope:
   - Testing with command-line arguments or flags


### PR DESCRIPTION
## Summary

Consolidates three redundant UC success criteria into one integration-level criterion and adds dependency rationale to all flow steps. Reduces S-item count by 67% while preserving full AC traceability.

## Changes

- Consolidated S1/S2/S3 into a single S1 that exercises AC1 and AC2 as an end-to-end integration check
- Added sequencing justification to F2-F5 explaining why temporal ordering matters

## Test plan

- [x] `mage analyze` passes (0 schema errors)
- [x] S-item traces reference valid AC IDs

Closes #33