### PR TITLE
GH-53: Upgrade cobbler-scaffold and align docs/

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2 h1:tl6q5Uww1wUkH5t/CaUcmrFSgC6DcWKpnOU+xEkQW9E=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4 h1:wov7r8qqD9P82ehLBsMJY26P6HvhOPB5En7J3KJ7M5A=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260308.2 to v0.20260308.4, picking up support for structured acceptance_criteria, success_criteria, and semantic_model fields. PRDs and UCs already use the structured format from GH-33. The `depends_on` field for roadmap releases is not yet supported in the Go struct, so it is deferred.

## Changes

- Upgraded cobbler-scaffold v0.20260308.2 → v0.20260308.4 in magefiles/go.mod and go.sum
- Verified PRDs use structured `acceptance_criteria` with id/criterion/traces (already done in GH-33)
- Verified UCs use structured `success_criteria` with id/criterion/traces (already done in GH-33)
- `depends_on` for road-map.yaml deferred: cobbler-scaffold v0.20260308.4 RoadmapRelease struct does not have the field yet

## Test plan

- [x] `mage analyze` passes with zero errors
- [x] Schema validation passes (0 errors)
- [x] Constitution drift check passes (0 files)

Closes #53