### PR TITLE
GH-63: Add prd003-config specifications for rel04.0

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -28,15 +28,18 @@ overview:
 interfaces:
   - name: Binary CLI
     summary: |
-      The compiled binary supports --version, --name, and --help flags via
-      the Go standard library flag package. With no flags it writes
-      "Hello, World!\n" to stdout and exits 0. Unknown flags produce an
-      error on stderr and exit 1.
-    data_structures: []
+      The compiled binary supports --version, --name, --help, and --config
+      flags via the Go standard library flag package. With no flags it writes
+      "Hello, World!\n" to stdout and exits 0. The --config flag loads a JSON
+      file that sets greeting name, template, and output format. Unknown flags
+      produce an error on stderr and exit 1.
+    data_structures:
+      - "Config: struct with Name, Template, Format string fields, parsed from JSON via encoding/json"
     operations:
-      - "main(): parse flags and dispatch to greeting, version, or error path"
+      - "main(): parse flags and dispatch to greeting, version, config, or error path"
       - "--version: print Version constant to stdout and exit 0"
       - "--name <value>: print 'Hello, <value>!' to stdout and exit 0"
+      - "--config <path>: load JSON config file and apply settings"
       - "--help: print usage to stderr and exit 0"
       - "unknown flag: print error to stderr and exit 1"
 
@@ -59,14 +62,18 @@ components:
   - name: Binary
     responsibility: |
       Single-file Go program with flag parsing. Prints a greeting to stdout
-      and exits 0 by default. Supports --version, --name, and --help flags.
-      Zero external dependencies. The Version constant is defined in
-      cmd/sdd-hello-world/version.go.
+      and exits 0 by default. Supports --version, --name, --help, and
+      --config flags. The --config flag loads a JSON file that sets greeting
+      name, template, and output format. Zero external dependencies (JSON
+      parsing uses encoding/json from stdlib). The Version constant is
+      defined in cmd/sdd-hello-world/version.go.
     capabilities:
-      - Print greeting to stdout (default or personalized via --name)
+      - Print greeting to stdout (default or personalized via --name or config)
       - Print version to stdout via --version
+      - Load JSON config file via --config (name, template, format fields)
+      - Output greeting as JSON object when config format is "json"
       - Print usage to stderr via --help
-      - Report errors on stderr and exit 1 for unknown flags
+      - Report errors on stderr and exit 1 for unknown flags or invalid config
     references: []
 
   - name: Magefiles
@@ -143,6 +150,7 @@ implementation_status:
     - done: Tagged and published as Go module
     - done: PRD, use case, and test suite for hello world binary (rel02.0)
     - done: PRD, use cases, and test suite for CLI enhancements (rel03.0)
+    - done: PRD, use cases, and test suite for config file support (rel04.0)
     - pending: Go binary (cmd/sdd-hello-world/main.go, cmd/sdd-hello-world/version.go)
 
 related_documents:
@@ -164,5 +172,13 @@ related_documents:
     purpose: Help and error handling use case for release 03.0 (R3, R4)
   - doc: docs/specs/test-suites/test-rel03.0.yaml
     purpose: Test suite validating CLI enhancement use cases
+  - doc: docs/specs/product-requirements/prd003-config.yaml
+    purpose: Config file requirements (loading, behavior, precedence, validation)
+  - doc: docs/specs/use-cases/rel04.0-uc004-config-loading.yaml
+    purpose: Config loading and behavior use case for release 04.0 (R1, R2, R3)
+  - doc: docs/specs/use-cases/rel04.0-uc005-config-validation.yaml
+    purpose: Config validation and error handling use case for release 04.0 (R4)
+  - doc: docs/specs/test-suites/test-rel04.0.yaml
+    purpose: Test suite validating config file use cases
   - doc: configuration.yaml
     purpose: Orchestrator configuration

--- a/docs/SPECIFICATIONS.yaml
+++ b/docs/SPECIFICATIONS.yaml
@@ -7,10 +7,11 @@ title: SDD Hello World Specifications
 overview: |
   SDD Hello World is a minimal test fixture for cobbler-scaffold. The project
   specifies a Go binary that prints "Hello, World!" and exits 0, with CLI
-  enhancements (version, name, help flags) in a second release. The
-  cobbler-scaffold generation pipeline reads the PRDs and produces the Go
-  source files. For goals and boundaries see VISION.yaml. For components and
-  structure see ARCHITECTURE.yaml.
+  enhancements (version, name, help flags) in a second release and JSON
+  configuration file support in a third. The cobbler-scaffold generation
+  pipeline reads the PRDs and produces the Go source files. For goals and
+  boundaries see VISION.yaml. For components and structure see
+  ARCHITECTURE.yaml.
 
 roadmap_summary:
   - version: "01.0"
@@ -25,6 +26,11 @@ roadmap_summary:
     status: pending
   - version: "03.0"
     name: CLI enhancements
+    use_cases_done: 0
+    use_cases_total: 2
+    status: pending
+  - version: "04.0"
+    name: Configuration file support
     use_cases_done: 0
     use_cases_total: 2
     status: pending
@@ -45,6 +51,15 @@ prd_index:
       produce an error on stderr with exit code 1. Uses Go standard library
       flag package only.
     path: docs/specs/product-requirements/prd002-cli-enhancements.yaml
+  - id: prd003-config
+    title: Configuration File Support
+    summary: |
+      Adds JSON configuration file support via --config flag. Config sets
+      greeting name, template, and output format. Flag precedence rules
+      resolve conflicts between --name and config. Validation handles
+      missing files and malformed JSON. Uses encoding/json from the Go
+      standard library.
+    path: docs/specs/product-requirements/prd003-config.yaml
 
 use_case_index:
   - id: rel02.0-uc001-build-hello-world
@@ -65,6 +80,18 @@ use_case_index:
     status: pending
     test_suite: test-rel03.0
     path: docs/specs/use-cases/rel03.0-uc003-help-and-errors.yaml
+  - id: rel04.0-uc004-config-loading
+    title: Configuration File Loading and Behavior
+    release: "04.0"
+    status: pending
+    test_suite: test-rel04.0
+    path: docs/specs/use-cases/rel04.0-uc004-config-loading.yaml
+  - id: rel04.0-uc005-config-validation
+    title: Configuration File Validation and Errors
+    release: "04.0"
+    status: pending
+    test_suite: test-rel04.0
+    path: docs/specs/use-cases/rel04.0-uc005-config-validation.yaml
 
 test_suite_index:
   - id: test-rel02.0
@@ -80,6 +107,13 @@ test_suite_index:
       - rel03.0-uc003-help-and-errors
     test_case_count: 7
     path: docs/specs/test-suites/test-rel03.0.yaml
+  - id: test-rel04.0
+    title: Test Suite for Release 04.0 — Configuration File Support
+    traces:
+      - rel04.0-uc004-config-loading
+      - rel04.0-uc005-config-validation
+    test_case_count: 8
+    path: docs/specs/test-suites/test-rel04.0.yaml
 
 prd_to_use_case_mapping:
   - use_case: rel02.0-uc001-build-hello-world
@@ -102,10 +136,24 @@ prd_to_use_case_mapping:
       information, and unknown flags produce an error with exit code 1.
     coverage: R3.1, R3.2, R4.1, R4.2, R4.3
 
+  - use_case: rel04.0-uc004-config-loading
+    prd: prd003-config
+    why_required: |
+      Validates config file loading, config-driven behavior (name, template,
+      format), and flag precedence when --name or --version is combined with
+      --config.
+    coverage: R1.1, R1.2, R1.3, R2.1, R2.2, R2.3, R3.1, R3.2, R3.3
+  - use_case: rel04.0-uc005-config-validation
+    prd: prd003-config
+    why_required: |
+      Validates error handling for missing config files, malformed JSON, and
+      unknown fields in the config file.
+    coverage: R4.1, R4.2, R4.3
+
 coverage_gaps: |
-  No coverage gaps. All prd002-cli-enhancements requirements are covered:
-  R1 and R2 by UC002 (greeting and version), R3 and R4 by UC003 (help and
-  errors).
+  No coverage gaps. All PRD requirements are covered: prd001 by UC001,
+  prd002 R1-R2 by UC002, prd002 R3-R4 by UC003, prd003 R1-R3 by UC004,
+  prd003 R4 by UC005.
 
 references:
   - VISION.yaml

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -41,6 +41,22 @@ releases:
       - id: rel03.0-uc003-help-and-errors
         status: pending
 
+  - version: "04.0"
+    name: Configuration file support
+    status: pending
+    description: |
+      We add JSON configuration file support via a --config flag. The config
+      sets greeting name, template, and output format. This release provides
+      12 R-items across 4 groups, requiring three or more stitch tasks and
+      exercising cross-batch duplicate detection and partial UC completion
+      gating in the cobbler-scaffold pipeline.
+    use_cases:
+      - id: rel04.0-uc004-config-loading
+        status: pending
+      - id: rel04.0-uc005-config-validation
+        status: pending
+
 prioritization:
   - Release 02.0 implements the binary from specifications so the generation pipeline has reproducible work to propose and execute.
   - Release 03.0 adds CLI flags to exercise multi-cycle generation with multiple use cases per release.
+  - Release 04.0 adds config file support to exercise cross-batch duplicate detection with 12 R-items across 3+ stitch tasks.

--- a/docs/specs/product-requirements/prd003-config.yaml
+++ b/docs/specs/product-requirements/prd003-config.yaml
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: prd003-config
+title: Configuration File Support
+
+problem: |
+  The hello world binary accepts flags for individual settings but has no way
+  to load multiple settings from a file. With only two PRDs and 17 R-items,
+  the cobbler-scaffold generation pipeline completes in two to three stitch
+  cycles, which is too few to exercise cross-batch duplicate detection and
+  partial UC completion gating. We need a third PRD with enough R-items to
+  require three or more stitch tasks, exercising the requirement tracking
+  pipeline at scale. A JSON configuration file adds 12 R-items across four
+  groups while preserving the zero-dependency constraint (encoding/json is
+  in the Go standard library).
+
+goals:
+  - id: G1
+    text: |
+      Add a --config flag that loads greeting settings from a JSON file,
+      enabling name, template, and output format configuration without
+      requiring multiple command-line flags.
+  - id: G2
+    text: |
+      Provide enough distinct requirements (12 R-items across 4 groups) to
+      exercise multi-task generation with cross-batch duplicate detection
+      and partial UC completion in the cobbler-scaffold pipeline.
+
+requirements:
+  R1:
+    title: Config file loading
+    items:
+      - R1.1: The binary must accept a --config flag that takes a file path argument.
+      - R1.2: The binary must parse the config file as JSON with three optional string fields named "name", "template", and "format".
+      - R1.3: When --config is not provided, no config file is loaded and all behavior defaults apply as specified in prd001 and prd002.
+  R2:
+    title: Config-driven behavior
+    items:
+      - R2.1: When the config file contains a "name" field, the binary must use its value as the greeting name, equivalent to providing --name with the same value.
+      - R2.2: When the config file contains a "template" field, the binary must use its value as the greeting format string. The template must contain exactly one %s verb which is replaced by the name.
+      - R2.3: When the config file contains a "format" field set to "json", the binary must output a JSON object with "greeting" and "name" string fields to stdout instead of plain text. When set to "text" or absent, the binary must output plain text.
+  R3:
+    title: Flag precedence
+    items:
+      - R3.1: When both --name and a config name field are provided, --name must take precedence over the config name.
+      - R3.2: When --version is provided alongside --config, the binary must print the version and exit 0 without reading the config file.
+      - R3.3: When the config file sets name and --name is not provided, the config name must be used for the greeting.
+  R4:
+    title: Config validation
+    items:
+      - R4.1: When --config points to a file that does not exist, the binary must print an error message to stderr and exit with code 1.
+      - R4.2: When --config points to a file containing invalid JSON, the binary must print an error message to stderr and exit with code 1.
+      - R4.3: When the config file contains fields not defined in R1.2, the binary must silently ignore them.
+
+non_goals:
+  - Nested or hierarchical configuration
+  - Environment variable configuration sources
+  - Config file auto-discovery (e.g., searching home directory)
+  - YAML, TOML, or INI config formats
+  - Adding external dependencies to go.mod
+
+acceptance_criteria:
+  - id: AC1
+    criterion: Running the binary with --config pointing to a valid JSON file containing {"name":"Bob"} prints "Hello, Bob!\n" to stdout and exits with code 0.
+    traces: [R1.1, R1.2, R1.3, R2.1]
+  - id: AC2
+    criterion: Running the binary with --config pointing to a valid JSON file containing {"template":"Greetings, %s!"} prints "Greetings, World!\n" to stdout and exits with code 0.
+    traces: [R1.2, R2.2]
+  - id: AC3
+    criterion: Running the binary with --config pointing to a valid JSON file containing {"format":"json"} prints a JSON object with greeting and name fields to stdout and exits with code 0.
+    traces: [R2.3]
+  - id: AC4
+    criterion: Running the binary with --config config.json --name Alice where config.json contains {"name":"Bob"} prints "Hello, Alice!\n" (--name wins).
+    traces: [R3.1, R3.3]
+  - id: AC5
+    criterion: Running the binary with --config config.json --version prints the version and exits 0 without reading config.json.
+    traces: [R3.2]
+  - id: AC6
+    criterion: Running the binary with --config nonexistent.json prints an error to stderr and exits with code 1.
+    traces: [R4.1]
+  - id: AC7
+    criterion: Running the binary with --config pointing to a file containing invalid JSON prints an error to stderr and exits with code 1.
+    traces: [R4.2]
+  - id: AC8
+    criterion: Running the binary with --config pointing to a JSON file containing {"unknown_field":"value"} does not produce an error. The unknown field is ignored.
+    traces: [R4.3]

--- a/docs/specs/test-suites/test-rel04.0.yaml
+++ b/docs/specs/test-suites/test-rel04.0.yaml
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: test-rel04.0
+title: Test Suite for Release 04.0 — Configuration File Support
+
+release: "04.0"
+
+traces:
+  - rel04.0-uc004-config-loading
+  - rel04.0-uc005-config-validation
+
+preconditions:
+  - The sdd-hello-world binary is compiled from Go source files that include config file loading logic in cmd/sdd-hello-world/main.go.
+  - The binary accepts --config, --name, and --version flags.
+  - The go.mod file declares no external dependencies (JSON parsing uses encoding/json from the standard library).
+
+test_cases:
+  - name: Config name sets greeting name
+    inputs: |
+      Create a JSON file containing {"name":"Bob"}.
+      Run the compiled sdd-hello-world binary with --config pointing to it.
+    expected: |
+      Stdout contains exactly "Hello, Bob!" followed by a newline. Exit
+      code is 0.
+
+  - name: Config template changes greeting format
+    inputs: |
+      Create a JSON file containing {"template":"Greetings, %s!"}.
+      Run the compiled sdd-hello-world binary with --config pointing to it.
+    expected: |
+      Stdout contains exactly "Greetings, World!" followed by a newline.
+      Exit code is 0.
+
+  - name: Config JSON output format
+    inputs: |
+      Create a JSON file containing {"format":"json"}.
+      Run the compiled sdd-hello-world binary with --config pointing to it.
+    expected: |
+      Stdout contains a valid JSON object with "greeting" and "name"
+      string fields. Exit code is 0.
+
+  - name: Flag name overrides config name
+    inputs: |
+      Create a JSON file containing {"name":"Bob"}.
+      Run the compiled sdd-hello-world binary with --config pointing to it
+      and --name Alice.
+    expected: |
+      Stdout contains exactly "Hello, Alice!" followed by a newline. The
+      --name flag value takes precedence over the config name.
+
+  - name: Version flag ignores config
+    inputs: |
+      Create a JSON file containing {"name":"Bob"}.
+      Run the compiled sdd-hello-world binary with --config pointing to it
+      and --version.
+    expected: |
+      Stdout contains the Version constant value followed by a newline.
+      No greeting text appears. Exit code is 0.
+
+  - name: Missing config file produces error
+    inputs: |
+      Run the compiled sdd-hello-world binary with --config nonexistent.json.
+    expected: |
+      Stderr contains an error message about the missing file. Exit code
+      is 1. No greeting appears on stdout.
+
+  - name: Invalid JSON config produces error
+    inputs: |
+      Create a file containing "not valid json{".
+      Run the compiled sdd-hello-world binary with --config pointing to it.
+    expected: |
+      Stderr contains an error message about invalid JSON. Exit code is 1.
+      No greeting appears on stdout.
+
+  - name: Unknown config fields are ignored
+    inputs: |
+      Create a JSON file containing {"unknown_field":"value","name":"Eve"}.
+      Run the compiled sdd-hello-world binary with --config pointing to it.
+    expected: |
+      Stdout contains exactly "Hello, Eve!" followed by a newline. No
+      error appears on stderr. Exit code is 0.

--- a/docs/specs/use-cases/rel04.0-uc004-config-loading.yaml
+++ b/docs/specs/use-cases/rel04.0-uc004-config-loading.yaml
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: rel04.0-uc004-config-loading
+title: Configuration File Loading and Behavior
+
+summary: |
+  We run the sdd-hello-world binary with --config pointing to a JSON file
+  to verify that config-driven greeting behavior works. The config file sets
+  the name, template, and output format. When combined with --name, the flag
+  takes precedence. When combined with --version, the version is printed
+  without reading the config. This use case exercises the happy-path config
+  loading and flag precedence logic.
+
+actor: Developer or CI pipeline
+
+trigger: |
+  The compiled sdd-hello-world binary exists after a successful build, and
+  the user or test harness invokes it with --config pointing to a valid JSON
+  configuration file.
+
+flow:
+  - id: F1
+    text: Build the binary with go build ./cmd/sdd-hello-world.
+  - id: F2
+    text: Create a JSON config file with {"name":"Bob"} and run the binary with --config pointing to it. Capture stdout and exit code.
+  - id: F3
+    text: Verify stdout is "Hello, Bob!\n" and exit code is 0.
+  - id: F4
+    text: Create a JSON config file with {"template":"Greetings, %s!"} and run the binary with --config pointing to it. Capture stdout.
+  - id: F5
+    text: Verify stdout is "Greetings, World!\n" and exit code is 0.
+  - id: F6
+    text: Create a JSON config file with {"format":"json"} and run the binary with --config pointing to it. Capture stdout.
+  - id: F7
+    text: Verify stdout is a JSON object with "greeting" and "name" fields and exit code is 0.
+  - id: F8
+    text: Run the binary with --config {"name":"Bob"} and --name Alice. Capture stdout.
+  - id: F9
+    text: Verify stdout is "Hello, Alice!\n" (--name overrides config name).
+  - id: F10
+    text: Run the binary with --config config.json and --version. Capture stdout and exit code.
+  - id: F11
+    text: Verify stdout contains the version string, no greeting appears, and exit code is 0.
+
+touchpoints:
+  - id: T1
+    text: |
+      Binary component (cmd/sdd-hello-world/main.go) — exercises the config
+      file loading, JSON parsing, template application, JSON output mode,
+      and flag precedence logic. Implements prd003-config R1.1, R1.2, R1.3,
+      R2.1, R2.2, R2.3, R3.1, R3.2, R3.3.
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The binary with --config pointing to {"name":"Bob"} prints "Hello, Bob!\n"
+      to stdout and exits with code 0.
+    traces: [AC1]
+  - id: S2
+    criterion: |
+      The binary with --config pointing to {"template":"Greetings, %s!"} prints
+      "Greetings, World!\n" to stdout and exits with code 0.
+    traces: [AC2]
+  - id: S3
+    criterion: |
+      The binary with --config pointing to {"format":"json"} prints a JSON
+      object with greeting and name fields to stdout and exits with code 0.
+    traces: [AC3]
+  - id: S4
+    criterion: |
+      When --name Alice and --config {"name":"Bob"} are both provided, stdout
+      is "Hello, Alice!\n" (flag wins).
+    traces: [AC4]
+  - id: S5
+    criterion: |
+      When --version and --config are both provided, the version is printed
+      and exit code is 0. The config file is not read.
+    traces: [AC5]
+
+out_of_scope:
+  - Config file with all three fields set simultaneously
+  - Config file in non-JSON formats
+  - Config file permissions or ownership checks
+
+test_suite: test-rel04.0

--- a/docs/specs/use-cases/rel04.0-uc005-config-validation.yaml
+++ b/docs/specs/use-cases/rel04.0-uc005-config-validation.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: rel04.0-uc005-config-validation
+title: Configuration File Validation and Errors
+
+summary: |
+  We run the sdd-hello-world binary with --config pointing to invalid or
+  missing files to verify that error handling works correctly. A nonexistent
+  file and malformed JSON both produce stderr errors and exit code 1. Unknown
+  fields in valid JSON are silently ignored. This use case exercises the
+  validation and error paths of the config loading logic.
+
+actor: Developer or CI pipeline
+
+trigger: |
+  The compiled sdd-hello-world binary exists after a successful build, and
+  the user or test harness invokes it with --config pointing to a nonexistent
+  file, a file with invalid JSON, or a file with unknown fields.
+
+flow:
+  - id: F1
+    text: Build the binary with go build ./cmd/sdd-hello-world.
+  - id: F2
+    text: Run the binary with --config nonexistent.json. Capture stderr and exit code.
+  - id: F3
+    text: Verify stderr contains an error message about the missing file and exit code is 1.
+  - id: F4
+    text: Create a file containing "not valid json{" and run the binary with --config pointing to it. Capture stderr and exit code.
+  - id: F5
+    text: Verify stderr contains an error message about invalid JSON and exit code is 1.
+  - id: F6
+    text: Create a JSON file containing {"unknown_field":"value","name":"Eve"} and run the binary with --config pointing to it. Capture stdout and exit code.
+  - id: F7
+    text: Verify stdout is "Hello, Eve!\n", no error appears on stderr, and exit code is 0 (unknown field ignored).
+
+touchpoints:
+  - id: T1
+    text: |
+      Binary component (cmd/sdd-hello-world/main.go) — exercises the config
+      file error handling for missing files, malformed JSON, and unknown
+      fields. Implements prd003-config R4.1, R4.2, R4.3.
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The binary with --config pointing to a nonexistent file prints an error
+      to stderr and exits with code 1. No greeting appears on stdout.
+    traces: [AC6]
+  - id: S2
+    criterion: |
+      The binary with --config pointing to invalid JSON prints an error to
+      stderr and exits with code 1. No greeting appears on stdout.
+    traces: [AC7]
+  - id: S3
+    criterion: |
+      The binary with --config pointing to JSON with unknown fields prints
+      the greeting normally. The unknown fields are silently ignored.
+    traces: [AC8]
+
+out_of_scope:
+  - Config file with read permission errors
+  - Config file that is a directory
+  - Empty config file (valid JSON with no fields)
+
+test_suite: test-rel04.0


### PR DESCRIPTION
## Summary

Add a third PRD with JSON configuration file support to exercise cobbler-scaffold
requirement tracking features (cobbler-scaffold#1378). Provides 12 R-items across
4 groups — enough to require 3+ stitch tasks and test cross-batch duplicate detection
and partial UC completion gating.

## Changes

- prd003-config.yaml: 4 R-groups (loading, behavior, precedence, validation), 12 R-items, 8 ACs
- rel04.0-uc004-config-loading.yaml: happy path UC covering R1-R3 (9 R-items)
- rel04.0-uc005-config-validation.yaml: error path UC covering R4 (3 R-items)
- test-rel04.0.yaml: 8 test cases covering both UCs
- road-map.yaml: added rel04.0 with 2 UCs
- SPECIFICATIONS.yaml: added prd003, uc004, uc005, test-rel04.0, coverage mappings
- ARCHITECTURE.yaml: added --config flag, Config struct, config capabilities

## Test plan

- [x] `mage analyze` passes (0 errors, warnings are pre-existing)
- [x] All R-items covered by ACs
- [x] All PRD requirements mapped to use cases

Closes #63