### PR TITLE
GH-55: Upgrade cobbler-scaffold v0.20260308.4 → v0.20260309.1

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260309.1
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4 h1:wov7r8qqD9P82ehLBsMJY26P6HvhOPB5En7J3KJ7M5A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260309.1 h1:4VfTQIGknMV9GhZH9cVrkTpuBLp63iCX4e/8ek40kjM=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260309.1/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260308.4 to v0.20260309.1. All `.claude/` files are already synchronized — no content changes needed beyond the Go dependency.

## Changes

- Upgraded cobbler-scaffold v0.20260308.4 → v0.20260309.1 in magefiles/go.mod and go.sum
- New analyzer feature: unreachable UCs check (0 found)

## Test plan

- [x] `mage analyze` passes with zero errors
- [x] Schema validation passes (0 errors)
- [x] Constitution drift check passes (0 files)
- [x] `.claude/` files verified in sync with scaffold source

Closes #55