### PR TITLE
GH-65: Upgrade cobbler-scaffold v0.20260309.1 → v0.20260316.1

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260309.1
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260316.1
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260309.1 h1:4VfTQIGknMV9GhZH9cVrkTpuBLp63iCX4e/8ek40kjM=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260309.1/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260316.1 h1:m2JvTwu8N/80+WeYEU1KA3VzJ+7xVNgNbUnQk9AKoGs=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260316.1/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260309.1 to v0.20260316.1, picking up generator backoff, stale branch recovery, podman removal, prompt efficiency improvements, contract tasks, batch measure (3x cost reduction), and build/test guidance.

## Changes

- Updated `magefiles/go.mod` cobbler-scaffold dependency v0.20260309.1 → v0.20260316.1
- Updated `magefiles/go.sum` with new checksums
- No .claude/ file changes needed (already in sync)

## Test plan

- [x] `mage analyze` passes
- [x] All consistency checks pass (3 PRDs, 5 use cases, 3 test suites)

Closes #65