### PR TITLE
GH-69: Reduce measure prompt size via context_exclude

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -24,6 +24,11 @@ project:
         docs/engineering/eng*.yaml
         docs/constitutions/*.yaml
         docs/*.yaml
+    context_exclude: |
+        docs/constitutions/
+        docs/SPECIFICATIONS.yaml
+        docs/prompts/
+        docs/engineering/
     seed_files:
         cmd/sdd-hello-world/version.go: magefiles/version.go.tmpl
 generation:


### PR DESCRIPTION
## Summary

Adds `context_exclude` to `configuration.yaml` to remove ~68K bytes (~17K tokens) of redundant content from the measure prompt. Constitutions, SPECIFICATIONS.yaml, and prompt templates were being loaded twice — once via `context_sources` and once as separate prompt fields. This should eliminate the empty-task-list failures seen in cobbler-scaffold e2e tests.

## Changes

- Added `context_exclude` field to `project:` section in `configuration.yaml`
- Excludes `docs/constitutions/`, `docs/SPECIFICATIONS.yaml`, `docs/prompts/`, and `docs/engineering/`

## Test plan

- [ ] `mage analyze` passes
- [ ] Tag a new release and run cobbler-scaffold `mage test:usecase` 3 times
- [ ] MeasureCreatesIssues passes consistently

Closes #69