### PR TITLE
GH-67: Upgrade cobbler-scaffold v0.20260316.1 → v0.20260403.0

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -16,7 +16,7 @@ project:
         docs/ARCHITECTURE.yaml
         docs/SPECIFICATIONS.yaml
         docs/road-map.yaml
-        docs/specs/product-requirements/prd*.yaml
+        docs/specs/software-requirements/srd*.yaml
         docs/specs/use-cases/rel*.yaml
         docs/specs/test-suites/test-rel*.yaml
         docs/specs/dependency-map.yaml

--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -102,7 +102,7 @@ design_decisions:
   - id: 2
     title: Specification-driven code generation
     decision: |
-      We include a PRD (prd001-hello-world-binary), a use case, and a test suite
+      We include an SRD (srd001-hello-world-binary), a use case, and a test suite
       that specify the binary's requirements. The cobbler-scaffold measure phase
       reads these specifications and proposes implementation tasks when the Go
       source files are absent. This makes the project a reliable, reproducible
@@ -110,7 +110,7 @@ design_decisions:
     benefits:
       - The measure agent has anchored requirements to propose tasks against
       - Each generation cycle can produce the binary from specifications alone
-      - The test suite validates that generated code meets the PRD requirements
+      - The test suite validates that generated code meets the SRD requirements
     alternatives_rejected:
       - "No specs: measure agent finds nothing to propose when source is absent"
 
@@ -148,9 +148,9 @@ implementation_status:
     - done: Configuration (configuration.yaml)
     - done: Documentation (VISION.yaml, ARCHITECTURE.yaml, road-map.yaml, constitutions)
     - done: Tagged and published as Go module
-    - done: PRD, use case, and test suite for hello world binary (rel02.0)
-    - done: PRD, use cases, and test suite for CLI enhancements (rel03.0)
-    - done: PRD, use cases, and test suite for config file support (rel04.0)
+    - done: SRD, use case, and test suite for hello world binary (rel02.0)
+    - done: SRD, use cases, and test suite for CLI enhancements (rel03.0)
+    - done: SRD, use cases, and test suite for config file support (rel04.0)
     - pending: Go binary (cmd/sdd-hello-world/main.go, cmd/sdd-hello-world/version.go)
 
 related_documents:
@@ -158,13 +158,13 @@ related_documents:
     purpose: Project purpose, scope, and success criteria
   - doc: docs/road-map.yaml
     purpose: Release schedule and phase status
-  - doc: docs/specs/product-requirements/prd001-hello-world-binary.yaml
+  - doc: docs/specs/software-requirements/srd001-hello-world-binary.yaml
     purpose: Binary requirements (file structure, runtime behavior)
   - doc: docs/specs/use-cases/rel02.0-uc001-build-hello-world.yaml
     purpose: Build and run use case for release 02.0
   - doc: docs/specs/test-suites/test-rel02.0.yaml
     purpose: Test suite validating the binary use case
-  - doc: docs/specs/product-requirements/prd002-cli-enhancements.yaml
+  - doc: docs/specs/software-requirements/srd002-cli-enhancements.yaml
     purpose: CLI flag requirements (version, name, help, error handling)
   - doc: docs/specs/use-cases/rel03.0-uc002-greeting-and-version.yaml
     purpose: Greeting and version flag use case for release 03.0 (R1, R2)
@@ -172,7 +172,7 @@ related_documents:
     purpose: Help and error handling use case for release 03.0 (R3, R4)
   - doc: docs/specs/test-suites/test-rel03.0.yaml
     purpose: Test suite validating CLI enhancement use cases
-  - doc: docs/specs/product-requirements/prd003-config.yaml
+  - doc: docs/specs/software-requirements/srd003-config.yaml
     purpose: Config file requirements (loading, behavior, precedence, validation)
   - doc: docs/specs/use-cases/rel04.0-uc004-config-loading.yaml
     purpose: Config loading and behavior use case for release 04.0 (R1, R2, R3)

--- a/docs/SPECIFICATIONS.yaml
+++ b/docs/SPECIFICATIONS.yaml
@@ -9,7 +9,7 @@ overview: |
   specifies a Go binary that prints "Hello, World!" and exits 0, with CLI
   enhancements (version, name, help flags) in a second release and JSON
   configuration file support in a third. The cobbler-scaffold generation
-  pipeline reads the PRDs and produces the Go source files. For goals and
+  pipeline reads the SRDs and produces the Go source files. For goals and
   boundaries see VISION.yaml. For components and structure see
   ARCHITECTURE.yaml.
 
@@ -36,22 +36,22 @@ roadmap_summary:
     status: pending
 
 prd_index:
-  - id: prd001-hello-world-binary
+  - id: srd001-hello-world-binary
     title: Hello World Binary
     summary: |
       Specifies the Go binary that prints "Hello, World!" and exits 0. Covers
       file structure (main.go, version.go), runtime behavior, and zero-dependency
       constraint.
-    path: docs/specs/product-requirements/prd001-hello-world-binary.yaml
-  - id: prd002-cli-enhancements
+    path: docs/specs/software-requirements/srd001-hello-world-binary.yaml
+  - id: srd002-cli-enhancements
     title: CLI Enhancements
     summary: |
       Adds command-line flag support: --version prints the version constant,
       --name personalizes the greeting, --help shows usage, and unknown flags
       produce an error on stderr with exit code 1. Uses Go standard library
       flag package only.
-    path: docs/specs/product-requirements/prd002-cli-enhancements.yaml
-  - id: prd003-config
+    path: docs/specs/software-requirements/srd002-cli-enhancements.yaml
+  - id: srd003-config
     title: Configuration File Support
     summary: |
       Adds JSON configuration file support via --config flag. Config sets
@@ -59,7 +59,7 @@ prd_index:
       resolve conflicts between --name and config. Validation handles
       missing files and malformed JSON. Uses encoding/json from the Go
       standard library.
-    path: docs/specs/product-requirements/prd003-config.yaml
+    path: docs/specs/software-requirements/srd003-config.yaml
 
 use_case_index:
   - id: rel02.0-uc001-build-hello-world
@@ -117,43 +117,43 @@ test_suite_index:
 
 prd_to_use_case_mapping:
   - use_case: rel02.0-uc001-build-hello-world
-    prd: prd001-hello-world-binary
+    prd: srd001-hello-world-binary
     why_required: |
-      The use case exercises all PRD requirements by building and running the
+      The use case exercises all SRD requirements by building and running the
       binary, verifying output, exit code, and file structure.
     coverage: R1.1, R1.2, R1.3, R2.1, R2.2, R2.3
   - use_case: rel03.0-uc002-greeting-and-version
-    prd: prd002-cli-enhancements
+    prd: srd002-cli-enhancements
     why_required: |
       Validates the stdout-producing flag paths: --version prints the Version
       constant, --name personalizes the greeting, and the default greeting is
       preserved when no flag is provided.
     coverage: R1.1, R1.2, R1.3, R2.1, R2.2, R2.3
   - use_case: rel03.0-uc003-help-and-errors
-    prd: prd002-cli-enhancements
+    prd: srd002-cli-enhancements
     why_required: |
       Validates the stderr-producing flag paths: --help prints usage
       information, and unknown flags produce an error with exit code 1.
     coverage: R3.1, R3.2, R4.1, R4.2, R4.3
 
   - use_case: rel04.0-uc004-config-loading
-    prd: prd003-config
+    prd: srd003-config
     why_required: |
       Validates config file loading, config-driven behavior (name, template,
       format), and flag precedence when --name or --version is combined with
       --config.
     coverage: R1.1, R1.2, R1.3, R2.1, R2.2, R2.3, R3.1, R3.2, R3.3
   - use_case: rel04.0-uc005-config-validation
-    prd: prd003-config
+    prd: srd003-config
     why_required: |
       Validates error handling for missing config files, malformed JSON, and
       unknown fields in the config file.
     coverage: R4.1, R4.2, R4.3
 
 coverage_gaps: |
-  No coverage gaps. All PRD requirements are covered: prd001 by UC001,
-  prd002 R1-R2 by UC002, prd002 R3-R4 by UC003, prd003 R1-R3 by UC004,
-  prd003 R4 by UC005.
+  No coverage gaps. All SRD requirements are covered: srd001 by UC001,
+  srd002 R1-R2 by UC002, srd002 R3-R4 by UC003, srd003 R1-R3 by UC004,
+  srd003 R4 by UC005.
 
 references:
   - VISION.yaml

--- a/docs/SPECIFICATIONS.yaml
+++ b/docs/SPECIFICATIONS.yaml
@@ -35,7 +35,7 @@ roadmap_summary:
     use_cases_total: 2
     status: pending
 
-prd_index:
+srd_index:
   - id: srd001-hello-world-binary
     title: Hello World Binary
     summary: |
@@ -115,36 +115,36 @@ test_suite_index:
     test_case_count: 8
     path: docs/specs/test-suites/test-rel04.0.yaml
 
-prd_to_use_case_mapping:
+srd_to_use_case_mapping:
   - use_case: rel02.0-uc001-build-hello-world
-    prd: srd001-hello-world-binary
+    srd: srd001-hello-world-binary
     why_required: |
       The use case exercises all SRD requirements by building and running the
       binary, verifying output, exit code, and file structure.
     coverage: R1.1, R1.2, R1.3, R2.1, R2.2, R2.3
   - use_case: rel03.0-uc002-greeting-and-version
-    prd: srd002-cli-enhancements
+    srd: srd002-cli-enhancements
     why_required: |
       Validates the stdout-producing flag paths: --version prints the Version
       constant, --name personalizes the greeting, and the default greeting is
       preserved when no flag is provided.
     coverage: R1.1, R1.2, R1.3, R2.1, R2.2, R2.3
   - use_case: rel03.0-uc003-help-and-errors
-    prd: srd002-cli-enhancements
+    srd: srd002-cli-enhancements
     why_required: |
       Validates the stderr-producing flag paths: --help prints usage
       information, and unknown flags produce an error with exit code 1.
     coverage: R3.1, R3.2, R4.1, R4.2, R4.3
 
   - use_case: rel04.0-uc004-config-loading
-    prd: srd003-config
+    srd: srd003-config
     why_required: |
       Validates config file loading, config-driven behavior (name, template,
       format), and flag precedence when --name or --version is combined with
       --config.
     coverage: R1.1, R1.2, R1.3, R2.1, R2.2, R2.3, R3.1, R3.2, R3.3
   - use_case: rel04.0-uc005-config-validation
-    prd: srd003-config
+    srd: srd003-config
     why_required: |
       Validates error handling for missing config files, malformed JSON, and
       unknown fields in the config file.

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -1,7 +1,7 @@
 # Design Constitution
 #
 # This constitution governs the design/architecting phase: creating VISION,
-# ARCHITECTURE, PRDs, use cases, test suites, and other documentation. It is
+# ARCHITECTURE, SRDs, use cases, test suites, and other documentation. It is
 # scaffolded into consuming projects so Claude knows how to write specs that
 # match the project's documentation standards.
 
@@ -10,13 +10,13 @@ articles:
     title: Specification-driven development
     rule: |
       Specifications are the source of truth. Code serves specifications, not
-      the other way around. No implementation code before the PRD and use case
+      the other way around. No implementation code before the SRD and use case
       exist. No implementation issue before a test suite exists for its use case.
 
   - id: D2
     title: YAML-first for structured docs
     rule: |
-      Use YAML for structured documents (VISION, ARCHITECTURE, PRDs, use cases,
+      Use YAML for structured documents (VISION, ARCHITECTURE, SRDs, use cases,
       test suites). Use markdown for prose-heavy guidelines and specifications
       summaries. YAML is machine-readable by design.
 
@@ -30,9 +30,9 @@ articles:
   - id: D4
     title: Traceability
     rule: |
-      Every PRD traces to VISION and ARCHITECTURE. Every use case traces to
-      PRDs (via touchpoints). Every test suite traces to use cases (via the
-      traces field). Code traces to PRDs via commit messages and comments.
+      Every SRD traces to VISION and ARCHITECTURE. Every use case traces to
+      SRDs (via touchpoints). Every test suite traces to use cases (via the
+      traces field). Code traces to SRDs via commit messages and comments.
 
   - id: D5
     title: Roadmap-driven releases
@@ -97,7 +97,7 @@ document_types:
     purpose: |
       States what the project is, why it exists, how success is measured, and
       what it is not. Orients stakeholders, new contributors, and downstream
-      docs (ARCHITECTURE, PRDs).
+      docs (ARCHITECTURE, SRDs).
 
   architecture:
     location: docs/ARCHITECTURE.yaml
@@ -116,11 +116,11 @@ document_types:
     purpose: |
       Describes how the system is built: components, interfaces, protocols,
       data flow, design decisions. Bridge between vision (what and why) and
-      PRDs (numbered requirements).
+      SRDs (numbered requirements).
 
-  prd:
-    location: "docs/specs/product-requirements/prd[NNN]-[feature-name].yaml"
-    format_rule: prd-format
+  srd:
+    location: "docs/specs/software-requirements/srd[NNN]-[feature-name].yaml"
+    format_rule: srd-format
     required_fields:
       - id
       - title
@@ -134,7 +134,7 @@ document_types:
       requirement_groups: "R1, R2, R3, ..."
       requirement_items: "R1.1, R1.2, R2.1, ..."
     purpose: |
-      Defines product requirements with numbered goals and requirements. Each
+      Defines software requirements with numbered goals and requirements. Each
       requirement starts with "must" or "must not" or a concrete verb. No scope
       creep - non_goals define explicit boundaries.
 
@@ -188,7 +188,7 @@ document_types:
       - references
     purpose: |
       Documents conventions, practices, and patterns above the code and
-      architecture. Not PRDs (no numbered requirements). Not architecture (no
+      architecture. Not SRDs (no numbered requirements). Not architecture (no
       component descriptions).
 
   specification:
@@ -199,16 +199,16 @@ document_types:
       - title
       - overview (multi-line text)
       - "roadmap_summary (list: version, name, use_cases_done, use_cases_total, status)"
-      - "prd_index (list: id, title, summary, path)"
+      - "srd_index (list: id, title, summary, path)"
       - "use_case_index (list: id, title, release, status, test_suite, path)"
       - "test_suite_index (list: id, title, traces, test_case_count, path)"
-      - "prd_to_use_case_mapping (list: use_case, prd, why_required, coverage)"
+      - "srd_to_use_case_mapping (list: use_case, srd, why_required, coverage)"
       - coverage_gaps (list or multi-line text)
     optional_fields:
       - traceability_diagram (Mermaid as multi-line string)
       - references
     purpose: |
-      Human-readable summary tying together PRDs, use cases, test suites, and
+      Human-readable summary tying together SRDs, use cases, test suites, and
       roadmap into one navigable page. Does not duplicate content; summarizes
       and shows relationships. Regenerate when any artifact changes.
 
@@ -220,7 +220,7 @@ document_types:
       (major.minor). Minor releases validate completed major releases.
 
 naming_conventions:
-  prd: "prd[NNN]-[feature-name].yaml (e.g., prd001-hello-world-binary.yaml)"
+  srd: "srd[NNN]-[feature-name].yaml (e.g., srd001-hello-world-binary.yaml)"
   use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel02.0-uc001-build-hello-world.yaml)"
   test_suite: "test-[use-case-id].yaml (e.g., test-rel02.0-uc001-build-hello-world.yaml)"
   engineering_guideline: "eng[NN]-[short-name].yaml (e.g., eng01-git-integration.yaml)"
@@ -238,10 +238,10 @@ writing_guidelines:
 traceability_model:
   vision: Goals and boundaries
   architecture: Components and interfaces (implements vision)
-  prds: Numbered requirements (architecture points to PRDs for detail)
+  srds: Numbered requirements (architecture points to SRDs for detail)
   use_cases: Tracer bullets (exercise architecture components via touchpoints)
   test_suites: Validation (validate use case success criteria)
-  code: Implementation (traces to PRDs via commit messages)
+  code: Implementation (traces to SRDs via commit messages)
 
 completeness_checklists:
   vision:
@@ -257,13 +257,13 @@ completeness_checklists:
   architecture:
     - id matches project name
     - overview.summary states what the system does and core insight
-    - interfaces list data structures, operations, announcements; link to PRD for full spec
-    - components list each major component with responsibility; link to PRD or use case
+    - interfaces list data structures, operations, announcements; link to SRD for full spec
+    - components list each major component with responsibility; link to SRD or use case
     - design_decisions are numbered with decision statement and benefits
     - project_structure shows directory paths and roles
     - File saved as ARCHITECTURE.yaml in docs/
 
-  prd:
+  srd:
     - id matches filename without extension
     - problem states what we solve and why it matters
     - goals are numbered (G1, G2, ...) and measurable
@@ -271,7 +271,7 @@ completeness_checklists:
     - Each requirement is specific and actionable
     - non_goals define what is out of scope
     - acceptance_criteria are checkable without ambiguity
-    - File saved as prd[NNN]-[feature-name].yaml
+    - File saved as srd[NNN]-[feature-name].yaml
 
   use_case:
     - id matches filename without extension
@@ -285,7 +285,7 @@ completeness_checklists:
 
   test_suite:
     - id matches filename
-    - traces lists at least one use case or PRD requirement
+    - traces lists at least one use case or SRD requirement
     - preconditions describe shared starting state
     - Each test case has name, inputs, expected outputs
     - Inputs use real commands and data
@@ -309,14 +309,14 @@ sections:
   - tag: document_types
     title: Document Types
     content: |
-      Seven document types are defined: vision, architecture, PRD, use case,
+      Seven document types are defined: vision, architecture, SRD, use case,
       test suite, engineering guideline, and specification. Each has a canonical
       location, format rule, required fields, and optional fields.
   - tag: naming_conventions
     title: Naming Conventions
     content: |
       File names follow strict patterns per document type (e.g.,
-      prd[NNN]-[feature].yaml, rel[NN].[N]-uc[NNN]-[name].yaml). Use lowercase
+      srd[NNN]-[feature].yaml, rel[NN].[N]-uc[NNN]-[name].yaml). Use lowercase
       kebab-case throughout.
   - tag: writing_guidelines
     title: Writing Guidelines
@@ -328,7 +328,7 @@ sections:
     title: Traceability Model
     content: |
       Every artifact traces through the chain: vision goals → architecture
-      components → PRD requirements → use case tracer bullets → test suite
+      components → SRD requirements → use case tracer bullets → test suite
       validation → code implementation.
   - tag: completeness_checklists
     title: Completeness Checklists

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -107,7 +107,7 @@ document_types:
       - title
       - overview (summary, lifecycle, coordination_pattern)
       - interfaces (data_structures, operations, announcements)
-      - components (name, responsibility, capabilities, references)
+      - components (name, provided_by, responsibility, capabilities, references)
       - design_decisions (id, title, decision, benefits, alternatives_rejected)
       - technology_choices
       - project_structure
@@ -128,13 +128,43 @@ document_types:
       - goals (G1, G2, ...)
       - requirements (R1.1, R1.2, ..., grouped by R1, R2, ...)
       - non_goals
-      - acceptance_criteria
+      - acceptance_criteria (list of objects with id, criterion, traces)
     numbering:
       goals: "G1, G2, G3, ..."
       requirement_groups: "R1, R2, R3, ..."
       requirement_items: "R1.1, R1.2, R2.1, ..."
+      requirement_id_format: "R{group}.{item} — numeric dotted only (e.g., R1.1, R2.3). Letter suffixes (R2a) are not valid and are flagged by mage analyze."
+      requirement_weight: |
+        Each R-item may optionally specify a weight indicating implementation
+        complexity. Weight is a positive integer with no upper bound, default 1.
+        The measure agent uses weights to batch requirements into tasks that fit
+        within the max_weight_per_task budget. Two YAML formats are supported:
+
+        Simple (weight defaults to 1):
+          - R1.1: Must accept -f flag
+
+        Weighted:
+          - R6.1:
+              text: Must scan each input line for known timestamp patterns
+              weight: 3
+      acceptance_criteria_ids: "AC1, AC2, AC3, ... (sequential within each SRD)"
+    acceptance_criteria_schema:
+      description: |
+        Each acceptance criterion is a structured object linking a checkable
+        statement to the requirement items it validates. Every R-item in the
+        SRD must appear in at least one AC's traces list.
+      fields:
+        - id: "AC1, AC2, ... (sequential)"
+        - criterion: "Checkable statement (the prose text)"
+        - traces: "List of R-item IDs this AC validates (e.g., [R1.1, R1.2])"
+      example: |
+        acceptance_criteria:
+          - id: AC1
+            criterion: Config struct includes all fields listed in R1 with YAML struct tags
+            traces: [R1.1, R1.2, R1.3]
+      completeness_rule: "Every R-item must appear in at least one AC's traces list"
     purpose: |
-      Defines software requirements with numbered goals and requirements. Each
+      Defines product requirements with numbered goals and requirements. Each
       requirement starts with "must" or "must not" or a concrete verb. No scope
       creep - non_goals define explicit boundaries.
 
@@ -149,12 +179,27 @@ document_types:
       - trigger
       - flow (F1, F2, ..., end-to-end steps)
       - touchpoints (T1, T2, ..., architecture elements exercised)
-      - success_criteria (S1, S2, ..., checkable outcomes)
+      - success_criteria (list of objects with id, criterion, traces)
       - out_of_scope
     numbering:
       flow_steps: "F1, F2, F3, ..."
       touchpoints: "T1, T2, T3, ..."
       success_criteria: "S1, S2, S3, ..."
+    success_criteria_schema:
+      description: |
+        Each success criterion is a structured object linking a checkable
+        outcome to the SRD acceptance criteria it exercises. The traces field
+        references SRD AC IDs using the format srdNNN-name ACN.
+      fields:
+        - id: "S1, S2, ... (sequential)"
+        - criterion: "Checkable outcome statement"
+        - traces: "List of SRD AC IDs (e.g., [srd001-orchestrator-core AC1])"
+      example: |
+        success_criteria:
+          - id: S1
+            criterion: New(config) returns a non-nil *Orchestrator
+            traces:
+              - srd001-orchestrator-core AC2
     purpose: |
       Describes a concrete usage of the architecture. One end-to-end path
       (tracer bullet) through the system. Leads to a proof-of-concept or demo.
@@ -169,6 +214,11 @@ document_types:
       - release (release ID this suite covers)
       - traces (list of use case IDs covered by this suite)
       - test_cases (list organized by use case sub-sections, each with name, inputs, expected outputs)
+    traces_format: |
+      The traces field in test_cases can reference three kinds of IDs:
+        - SRD R-item IDs: srdNNN-name RN.N (e.g., srd001-orchestrator-core R1.1)
+        - SRD AC IDs: srdNNN-name ACN (e.g., srd001-orchestrator-core AC1)
+        - UC S-item IDs: relNN.N-ucNNN-name SN (e.g., rel01.0-uc001-orchestrator-initialization S1)
     purpose: |
       Groups test cases for a full release. Each use case in the release appears
       as a sub-section within the suite. The YAML provides quick human/Claude
@@ -190,6 +240,26 @@ document_types:
       Documents conventions, practices, and patterns above the code and
       architecture. Not SRDs (no numbered requirements). Not architecture (no
       component descriptions).
+
+  interface_specification:
+    location: "docs/interfaces/ifc-[kebab-case-name].yaml"
+    format_rule: interface-specification-format
+    required_fields:
+      - id (matches filename without extension)
+      - name (must match ARCHITECTURE.yaml interface entry)
+      - summary (one to three sentences)
+    optional_fields:
+      - "data_structures (list: name, description, fields as typed field list)"
+      - "operations (list: name, description, parameters, returns)"
+      - announcements (list of events the interface emits)
+      - references (list of SRD or use case IDs)
+    purpose: |
+      Standalone, language-agnostic interface contract. Uses typed field
+      lists for data structures and typed parameter/return lists for
+      operations. Pure YAML throughout, consistent with D2. Replaces
+      Go-specific signatures inlined in ARCHITECTURE.yaml with
+      machine-parseable definitions. See eng10-interface-specifications for
+      the full format and examples.
 
   specification:
     location: docs/SPECIFICATIONS.yaml
@@ -219,11 +289,42 @@ document_types:
       status. Use cases are assigned to releases. Release numbering: rel[NN].[N]
       (major.minor). Minor releases validate completed major releases.
 
+  generation_run_report:
+    location: "docs/reports/generation-run-[N].md (e.g., generation-run-15.md)"
+    format_rule: generation-run-report-format
+    required_fields:
+      - "title: 'Generation Run [N]: [total LOC] LOC, $[total cost] — [one-line summary]'"
+      - "Configuration section: generation branch name, base branch, cobbler version,
+          model, max_turns, preserve_sources flag, issues_repo"
+      - "Cycle-by-cycle results section: table with columns cycle, issue title, status
+          (pass/fail/restart), stitch turns used, input tokens, output tokens,
+          cost USD, LOC delta"
+      - "Measure cycles section: table with columns cycle, issues proposed, input
+          tokens, output tokens, cost USD"
+      - "Cost analysis section: total input tokens, total output tokens, total cost USD,
+          total LOC produced, cost per KLOC; comparison table against prior runs
+          (run number, date, total LOC, total cost, cost/KLOC)"
+      - "Generated packages section: list of packages or modules produced with their LOC"
+      - "Failures and restarts section: for each failed stitch, the issue title, error
+          summary, and whether it was retried or abandoned"
+    purpose: |
+      Captures the full accounting of a completed generation run so that cost
+      trends, failure patterns, and per-package productivity can be tracked
+      across runs. Written once per generation after generator:stop completes.
+
+      Data source: before writing the report, read all history files from the
+      generation branch's merged tag (.cobbler/history/ under the
+      <generation-branch>-merged git tag): *-stitch-stats.yaml,
+      *-measure-stats.yaml, and *-stitch-report.yaml. These files contain
+      per-cycle token counts, costs, LOC deltas, and failure records.
+      Do not estimate; read the files.
+
 naming_conventions:
-  srd: "srd[NNN]-[feature-name].yaml (e.g., srd001-hello-world-binary.yaml)"
-  use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel02.0-uc001-build-hello-world.yaml)"
-  test_suite: "test-[use-case-id].yaml (e.g., test-rel02.0-uc001-build-hello-world.yaml)"
+  srd: "srd[NNN]-[feature-name].yaml (e.g., srd001-cupboard-core.yaml)"
+  use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel01.0-uc001-cupboard-lifecycle.yaml)"
+  test_suite: "test-[use-case-id].yaml (e.g., test-rel01.0-uc001-cupboard-lifecycle.yaml)"
   engineering_guideline: "eng[NN]-[short-name].yaml (e.g., eng01-git-integration.yaml)"
+  interface_specification: "ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml)"
   architecture: "ARCHITECTURE.yaml"
   vision: "VISION.yaml"
   specification: "SPECIFICATIONS.yaml"
@@ -270,14 +371,17 @@ completeness_checklists:
     - requirements are grouped (R1, R2, ...) with numbered items (R1.1, R1.2, ...)
     - Each requirement is specific and actionable
     - non_goals define what is out of scope
-    - acceptance_criteria are checkable without ambiguity
+    - acceptance_criteria are structured objects with id, criterion, and traces
+    - Every R-item appears in at least one AC's traces list
+    - Interactive requirements (prompting, confirmation) specify exact prompt text, accepted input values, case sensitivity, retry behavior on invalid input, and default behavior when stdin is not a terminal
     - File saved as srd[NNN]-[feature-name].yaml
 
   use_case:
     - id matches filename without extension
     - flow steps are numbered (F1, F2, ...), end-to-end, map to real components
     - touchpoints are numbered (T1, T2, ...) and list interfaces, components, protocols
-    - success_criteria are numbered (S1, S2, ...) and checkable without ambiguity
+    - touchpoints that cite SRDs must include R-group references (e.g., "srd030-md5sum R1, R2, R3"); bare SRD citations without R-groups break codereadiness computation
+    - success_criteria are structured objects with id, criterion, and traces to SRD AC IDs
     - test_suite references a corresponding test suite ID
     - Test suite YAML exists and traces back to this use case
     - Use case added to appropriate release in road-map.yaml
@@ -291,6 +395,15 @@ completeness_checklists:
     - Inputs use real commands and data
     - Expected outputs are specific and checkable
     - File saved as test-[use-case-id].yaml
+
+  interface_specification:
+    - id matches filename without extension (ifc-[kebab-case-name])
+    - name matches the corresponding ARCHITECTURE.yaml interface entry
+    - summary describes the interface contract in one to three sentences
+    - data_structures use typed field lists (name, type, description, required)
+    - operations have name, description, typed parameters, and typed returns
+    - references list SRD or use case IDs the interface traces to
+    - File saved as ifc-[kebab-case-name].yaml in docs/interfaces/
 
 sections:
   - tag: articles
@@ -309,9 +422,10 @@ sections:
   - tag: document_types
     title: Document Types
     content: |
-      Seven document types are defined: vision, architecture, SRD, use case,
-      test suite, engineering guideline, and specification. Each has a canonical
-      location, format rule, required fields, and optional fields.
+      Eight document types are defined: vision, architecture, SRD, use case,
+      test suite, engineering guideline, interface specification, and
+      specification. Each has a canonical location, format rule, required
+      fields, and optional fields.
   - tag: naming_conventions
     title: Naming Conventions
     content: |

--- a/docs/constitutions/execution.yaml
+++ b/docs/constitutions/execution.yaml
@@ -40,6 +40,50 @@ articles:
       Every item in Acceptance Criteria must be verified. Run tests if the
       criteria require it. Do not skip any criterion.
 
+  - id: E6
+    title: Non-goals enforcement
+    rule: |
+      Features listed in a SRD's non_goals must not be implemented. Do not
+      parse, accept, or act on flags, options, or behaviors that appear in
+      non_goals. If a requirement references a non_goal feature, treat it as
+      a specification error and skip the requirement with a TODO comment
+      citing the conflict.
+
+  - id: E7
+    title: Skip ambiguous requirements
+    rule: |
+      If a requirement is too vague to implement completely, do not implement
+      it partially. Skip the requirement entirely. Add a TODO comment citing
+      the requirement ID and describing what is missing from the specification.
+      A parsed-but-nonfunctional flag is worse than a missing flag.
+
+  - id: E8
+    title: Function size limit
+    rule: |
+      No function may exceed 40 lines of code. This is a hard limit, not a
+      guideline. If a function exceeds 40 lines, find a seam and split it
+      before the task is considered complete. Common seams: validation logic,
+      formatting logic, I/O operations, and branch-specific handling.
+
+  - id: E9
+    title: File size limit
+    rule: |
+      Each Go source file should stay under 500 lines of production code.
+      When a file exceeds this threshold, split by responsibility: main.go
+      (entry point and arg parsing), format.go (output formatting), and
+      additional files as needed. Test files follow the same split. pkg/
+      packages follow the same 500-line threshold.
+
+  - id: E10
+    title: DRY enforcement
+    rule: |
+      The duplication threshold is two. If you write the same logic twice,
+      extract it into a shared function. Common violations: entry display
+      logic duplicated across output modes, error formatting repeated in
+      multiple functions, path construction logic copied between list and
+      recurse paths. Before writing a function, search for existing code
+      that does the same thing.
+
 coding_standards:
   copyright_header: |
     Every Go file must start with the SPDX copyright header:
@@ -49,7 +93,10 @@ coding_standards:
   never_duplicate_code: |
     Before writing a function, search for existing code that does the same thing.
     When two pieces of code share logic, extract the common part. The threshold
-    is two: if you write the same thing twice, extract it.
+    is two: if you write the same thing twice, extract it. Common violations:
+    entry display logic duplicated across output modes, error formatting repeated
+    in multiple functions, path construction logic copied between list and recurse
+    paths. See article E10.
 
   design_patterns:
     - Strategy: Multiple implementations, caller picks one. Define interface, not if/else ladder.
@@ -68,7 +115,9 @@ coding_standards:
   struct_and_function_design: |
     Each struct represents one concept. Each function does one thing. If a
     function takes more than three parameters, group related parameters into a
-    config struct. If a function exceeds 40 lines, find a seam and split it.
+    config struct. No function may exceed 40 lines — this is a hard limit
+    enforced by article E8. Common seams for splitting: validation, formatting,
+    I/O, and branch-specific handling.
 
   error_handling: |
     Handle errors at the point they occur. Use guard clauses: check err != nil
@@ -100,7 +149,7 @@ coding_standards:
     - "JSON handling: encoding/json (stdlib)"
 
   naming_conventions:
-    exported: PascalCase (e.g., ProjectConfig)
+    exported: PascalCase (e.g., CupboardConfig)
     unexported: camelCase (e.g., cobblerConfig)
     cli_flags: kebab-case (e.g., --silence-agent)
     binary_constants: "bin prefix + PascalCase (e.g., binGit, binClaude)"
@@ -142,6 +191,38 @@ traceability:
     - "Engineering guidelines: docs/engineering/eng*.md"
     - "Vision: docs/VISION.yaml"
 
+build_and_test:
+  build_within_module: |
+    Always build and test from within the Go module directory. Do not cd
+    outside the module or create separate Go modules for testing. Use
+    `go build -o bin/<name> ./cmd/<name>/` for cmd/ binaries so outputs
+    land in bin/ (git-ignored). Do not use mage build or mage lint for
+    individual packages — use go build and go vet directly.
+
+  test_planning: |
+    Plan test prerequisites before writing test code. Determine what
+    binaries, fixtures, or reference implementations the tests need.
+    If cmd/ is empty during generation (code not yet written), skip
+    tests that require a built binary — use t.Skip with an explanatory
+    message. For tests that compare against reference binaries (e.g.
+    GNU coreutils), always use exec.LookPath and t.Skip if the
+    reference is not installed.
+
+  negative_tests: |
+    Do not write subtests that intentionally fail the test harness and
+    then fix them afterward. Every test you write must pass on the first
+    run. Use assertions (require.Equal, assert.Error) to check expected
+    error conditions. Use subprocess exec.Command to test exit codes
+    and signal handling rather than calling os.Exit in-process. Never
+    write a test that you expect to fail — if behavior is conditional,
+    use t.Skip or build tags.
+
+  repository_notes: |
+    Files with "collision" in the name are test fixtures for hash
+    collision testing — do not delete or modify them. Utilities that
+    write to stdout must install a SIGPIPE handler (signal.Notify +
+    signal.Reset) so piped output does not cause a broken-pipe crash.
+
 session_completion:
   git_managed_externally: true  # Do NOT run any git commands
   token_tracking: true  # Log tokens used per issue
@@ -155,7 +236,7 @@ session_completion:
     - Do NOT run any git commands (add, commit, status, init, rm .git)
     - Git is managed externally by the orchestrator
     - Your job is to write code and verify it works
-    - Do NOT interact with the issue tracker directly; GitHub Issues are managed by the orchestrator
+    - Do NOT use bd or cupboard commands
 
 technology:
   primary_language: Go
@@ -163,7 +244,7 @@ technology:
   cli_framework: cobra
   build_system: mage
   yaml_library: gopkg.in/yaml.v3
-  issue_tracker: github-issues
+  issue_tracker: cupboard
 
 git_conventions:
   note: Git is managed externally. Do NOT run any git commands.
@@ -172,10 +253,11 @@ sections:
   - tag: articles
     title: Core Principles
     content: |
-      Six principles govern the stitch phase: specification-first development,
+      Ten principles govern the stitch phase: specification-first development,
       commit traceability, no scope creep, session completion via
-      orchestrator-managed git, quality gate enforcement, and prohibition of
-      magic test values.
+      orchestrator-managed git, quality gate enforcement, non-goals enforcement,
+      skip-on-ambiguity, function size limits, file size limits, and DRY
+      enforcement.
   - tag: coding_standards
     title: Coding Standards
     content: |
@@ -198,8 +280,7 @@ sections:
     title: Technology Stack
     content: |
       The project uses Go with mage for build automation, cobra for CLI, viper
-      for configuration, yaml.v3 for YAML parsing, and GitHub Issues for task
-      tracking.
+      for configuration, yaml.v3 for YAML parsing, and cupboard for issue tracking.
   - tag: git_conventions
     title: Git Conventions
     content: |

--- a/docs/constitutions/execution.yaml
+++ b/docs/constitutions/execution.yaml
@@ -8,16 +8,16 @@ articles:
   - id: E1
     title: Specification-first
     rule: |
-      Code must correspond to existing PRDs and architecture. Read the PRDs and
+      Code must correspond to existing SRDs and architecture. Read the SRDs and
       ARCHITECTURE sections listed in Required Reading before writing code. Do
       not invent interfaces, types, or patterns not described in those docs.
 
   - id: E2
     title: Traceability
     rule: |
-      Commit messages must mention which PRDs (or aspects) are implemented.
-      Example: "Implement X (prd-feature-name R6-R7)". Where useful (package or
-      top-of-file comments), list the implemented PRDs.
+      Commit messages must mention which SRDs (or aspects) are implemented.
+      Example: "Implement X (srd-feature-name R6-R7)". Where useful (package or
+      top-of-file comments), list the implemented SRDs.
 
   - id: E3
     title: No scope creep
@@ -88,7 +88,7 @@ coding_standards:
     tests/: Integration tests.
     magefiles/: Build tooling. Flat directory. One file per concern.
 
-    Align package structure to PRD component structure. Each major component
+    Align package structure to SRD component structure. Each major component
     maps to one package. Avoid package names like util, common, helpers.
 
   standard_packages:
@@ -119,23 +119,23 @@ coding_standards:
 
 traceability:
   before_implementing:
-    - Identify related PRDs, ARCHITECTURE, use cases, test suites, guidelines, VISION
+    - Identify related SRDs, ARCHITECTURE, use cases, test suites, guidelines, VISION
     - Read the relevant sections so behavior, data shapes, and contracts are clear
     - Implement so the code conforms to the requirements and design described
 
   commit_message: |
-    Must mention which PRDs (or aspects) are being implemented. Prefer explicit:
-    "Implement X (prd-feature-name, prd-component)" or "Add Y per prd-feature R12".
-    If only parts touched, say so: "Implement operation X (prd-feature R8, R13)".
+    Must mention which SRDs (or aspects) are being implemented. Prefer explicit:
+    "Implement X (srd-feature-name, srd-component)" or "Add Y per srd-feature R12".
+    If only parts touched, say so: "Implement operation X (srd-feature R8, R13)".
 
   code_comments: |
-    At the top of a file or package doc, list implemented PRDs and architecture
+    At the top of a file or package doc, list implemented SRDs and architecture
     sections. Do not repeat this in every function; use file- or package-level
     comments only.
 
   reference_paths:
     - "Architecture: docs/ARCHITECTURE.yaml"
-    - "PRDs: docs/specs/product-requirements/prd*.yaml"
+    - "SRDs: docs/specs/software-requirements/srd*.yaml"
     - "Use cases: docs/specs/use-cases/rel*-uc*-*.yaml"
     - "Test suites (YAML specs): docs/specs/test-suites/test-rel-*.yaml"
     - "Release tests (Go): tests/rel-*/rel-*_test.go"
@@ -186,8 +186,8 @@ sections:
   - tag: traceability
     title: Traceability
     content: |
-      Before implementing, read the specified PRDs and architecture sections.
-      Commit messages must cite PRDs. Add a PRD list to file or package comments
+      Before implementing, read the specified SRDs and architecture sections.
+      Commit messages must cite SRDs. Add a SRD list to file or package comments
       where useful.
   - tag: session_completion
     title: Session Completion

--- a/docs/constitutions/go-style.yaml
+++ b/docs/constitutions/go-style.yaml
@@ -26,6 +26,28 @@ duplication: |
   share fields. Use helper functions to share behavior. Use interfaces to share
   contracts. The threshold is two: if you write the same thing twice, extract it.
 
+implementation_strategy: |
+  Write all source files before running any build or test commands. Plan the
+  full implementation (types, functions, imports) mentally, then write each
+  file in dependency order. Only run `go build` or `go vet` after all files
+  are written. This minimizes turns and avoids incremental compile-fix loops
+  that re-send the entire prompt context on each iteration.
+
+  When writing a new cmd/ utility:
+  1. Read the SRD and existing pkg/ contracts.
+  2. Write main.go with all flag parsing, logic, and error handling in one pass.
+  3. Write the test file with all test cases in one pass.
+  4. Run `go vet` once to verify compilation.
+  5. Run `go test` once to verify behavior.
+  6. Fix any issues in a single edit pass.
+
+  Common Go compilation errors to avoid on first write:
+  - Missing imports: always include fmt, os, io, strings when doing I/O.
+  - Unused imports: do not import packages speculatively.
+  - Type mismatches: check pkg/ contract signatures before calling.
+  - Missing error handling: every function that returns error must be checked.
+  - Unused variables: do not declare variables before they are needed.
+
 design_patterns:
   - name: Strategy
     description: |
@@ -92,12 +114,15 @@ design_patterns:
       callback registration when the producer should not know about its consumers.
 
 interfaces: |
-  Introduce an interface when you have two concrete implementations or when you
-  need to mock a dependency in tests. Do not create an interface for a single
-  implementation "just in case." Accept interfaces as parameters; return concrete
-  structs. Keep interfaces small: one to three methods. A large interface is a
-  sign that the abstraction is wrong. Split it into focused interfaces and compose
-  them.
+  Every boundary between a parent package and its internal sub-packages must be
+  defined by an interface. The parent package declares the interface; the internal
+  sub-package provides a concrete type that satisfies it. This applies even when
+  only one implementation exists today. The purpose is testability and explicit
+  contracts at every package boundary, not speculative abstraction.
+
+  Accept interfaces as parameters; return concrete structs. Keep interfaces small:
+  one to three methods. A large interface is a sign that the abstraction is wrong.
+  Split it into focused interfaces and compose them.
 
   Do not use interface{} or any as function parameters, return types, or struct
   fields. Every value must have a concrete type or a named interface. If a
@@ -115,6 +140,18 @@ struct_and_function_design: |
   generic names (Manager, Handler, Helper, Processor) unless the struct genuinely
   manages, handles, or processes a well-defined resource.
 
+receiver_conventions: |
+  Use a pointer receiver when the method mutates the receiver, when the struct
+  contains a mutex or sync primitive, or when the struct is large enough that
+  copying it on every call is wasteful. Use a value receiver for small, immutable
+  types where copying is cheap and the method does not modify the value. All
+  methods on a given type must use the same receiver kind — do not mix pointer
+  and value receivers on one type.
+
+  Name receivers with a one- or two-letter abbreviation of the type in lowercase:
+  o for Orchestrator, c for Config, s for Server. Never use self or this. The
+  receiver name must be consistent across all methods of the type.
+
 error_handling: |
   Handle errors at the point they occur. Use guard clauses: check err != nil and
   return early so the main logic stays at minimal indentation. Wrap errors with
@@ -123,6 +160,23 @@ error_handling: |
   discard an error with _ unless the operation is best-effort cleanup (e.g.,
   removing a temp file after the real work succeeded). When discarding, leave a
   comment explaining why.
+
+panic_vs_error: |
+  Return errors from all functions where the failure is a runtime condition —
+  missing files, bad user input, network failures, external API errors. Use panic
+  only for violations of a programming contract: a nil argument that must not be
+  nil by the function's documented precondition, an enum value that cannot exist,
+  an internal state that indicates a bug in the caller. Never panic on I/O
+  failures or user-provided data. A panic that can be triggered by an external
+  input is a bug.
+
+init_functions: |
+  Avoid init(). Every init() runs silently at program start, in dependency order,
+  with no way for the caller to handle errors or control timing. Acceptable uses
+  are registering stdlib drivers (e.g., _ "github.com/mattn/go-sqlite3") and
+  initializing package-level read-only lookup tables that cannot fail. If
+  initialization requires I/O or can return an error, use an explicit function
+  called from main() or from a constructor, not init().
 
 no_magic_strings: |
   Centralize all string literals that name external binaries, file paths, URLs,
@@ -133,23 +187,82 @@ no_magic_strings: |
   new external command or path, define the constant first, then use it. Never
   scatter raw string literals across files.
 
+configuration_via_yaml: |
+  All configuration must flow through configuration.yaml, loaded into the Config
+  struct by LoadConfig(). Do not read os.Getenv() to control orchestrator
+  behaviour, select execution modes, set file paths, or pass any option that a
+  user would otherwise set in configuration.yaml. Environment variables are not
+  a configuration channel in this project.
+
+  os.Getenv() is permitted only for two purposes: reading platform context
+  provided by the operating system (HOME, PATH, TMPDIR) and, in test code only,
+  reading variables that the test harness itself sets to override behaviour for
+  the test process. In both cases, the env var must be documented at the call
+  site with a comment explaining why it cannot come from Config.
+
+  The concrete consequence: if you find yourself writing os.Getenv("SOME_MODE")
+  or os.LookupEnv("SOME_FLAG") outside of those two narrow contexts, stop and
+  add a field to the relevant Config sub-struct instead.
+
+constants: |
+  Prefer typed constants over bare string or integer literals for values that
+  form a fixed set. Give the type a name: type totalMode int, then define the
+  values with iota in a const block. Use iota for sequential integer enums;
+  do not assign explicit integers unless the values must match an external
+  protocol. Group related constants in a single const block. Keep constants
+  unexported unless callers outside the package need them. Program names, file
+  paths, CLI flag names, label strings, and any literal that appears more than
+  once are candidates for a named constant.
+
 project_structure: |
   cmd/: Entry points. Minimal: parse flags, wire dependencies, start.
   internal/: Private implementation. Not importable outside this module. One
   package per component.
-  pkg/: Shared public types and interfaces. No implementation. The contract layer
-  between libraries.
+  pkg/: Public API surface. Exports types and delegates to internal sub-packages.
   tests/: Integration tests.
   magefiles/: Build tooling. Flat directory (mage constraint). One file per
   concern.
+
+  Every package organizes its implementation into internal/ sub-packages grouped
+  by domain concept. The parent package is the public API surface: it exports
+  types, defines interfaces, and delegates to internal sub-packages that provide
+  the implementation. Internal sub-packages are not importable outside the parent,
+  enforced by Go's internal/ directory convention. This rule applies uniformly to
+  packages under pkg/ and to top-level internal/ packages alike.
 
   Align package structure to SRD component structure. Each major component maps
   to one package. Avoid package names like util, common, helpers. Name packages
   by domain: storage, auth, config.
 
-  Define interfaces between major components. The pkg/ directory holds shared
-  types and interface contracts. The internal/ directory holds implementations
-  that satisfy those contracts.
+file_organization: |
+  Name files by the concern or feature they implement: scaffold.go, stitch.go,
+  analyze.go. Do not name files by kind: types.go, helpers.go, utils.go are
+  forbidden names. Place tests in <file>_test.go alongside the file they test.
+
+  Within a file, order declarations as follows: package-level constants and
+  types first, then constructors (NewXxx), then exported methods and functions,
+  then unexported helpers. main() goes last in cmd/ entry points. This ordering
+  means a reader can scan from top to bottom and encounter definitions before
+  uses.
+
+import_organization: |
+  Group imports into three blocks separated by blank lines, in this order:
+  standard library, external modules, internal packages. Within each block,
+  goimports ordering applies (alphabetical). Never use dot imports (. "pkg")
+  except in test files where the convention is established for a specific
+  package. Never use blank imports except for side-effect registration
+  (database drivers, image format codecs).
+
+  Correct example:
+    import (
+      "fmt"
+      "os"
+
+      "github.com/spf13/cobra"
+      "gopkg.in/yaml.v3"
+
+      "github.com/myorg/myrepo/internal/config"
+    )
 
 standard_packages:
   - "Build automation: magefile/mage"
@@ -169,38 +282,109 @@ struct_embedding: |
   CLI flags. Do not duplicate fields across sibling structs.
 
 naming_conventions:
-  - "Exported types and functions: PascalCase (e.g., ProjectConfig)"
+  - "Exported types and functions: PascalCase (e.g., CupboardConfig)"
   - "Unexported types and functions: camelCase (e.g., cobblerConfig)"
   - "CLI flags: kebab-case (e.g., --silence-agent)"
   - "Constants for binaries: bin prefix + PascalCase (e.g., binGit, binClaude)"
   - "Factory functions: New prefix (e.g., NewBackend())"
   - "Interface names: Action or capability (e.g., Table, Reader)"
+  - "Receiver names: one- or two-letter abbreviation of the type (e.g., o for Orchestrator, c for Config)"
+  - "Test helpers: verb-named functions describing what they do (e.g., buildFixture, writeFile, skipIfMissing)"
+  - "Typed enum types: singular noun (e.g., type totalMode int, type blockUnit int)"
+
+comment_style: |
+  Every exported symbol — function, type, variable, constant — must have a godoc
+  comment. The comment begins with the name of the symbol: // Orchestrator holds
+  the configuration and drives all build targets. Package-level documentation
+  goes in a doc comment immediately above the package clause. Do not create a
+  separate doc.go unless the package is too large to document inline.
+
+  Unexported functions need a comment only when the logic is non-obvious; a
+  function named buildMeasurePrompt does not need a comment saying "builds the
+  measure prompt." Avoid comments that restate what the code clearly shows.
+  Write comments that explain why, not what. When discarding an error, the
+  comment must explain the reasoning: // best-effort cleanup, error ignored.
+
+  Reference requirement IDs in comments when implementing a specific requirement:
+  // R1.2: truncate output at maxLines to bound memory usage.
 
 concurrency: |
   Pass context.Context as the first parameter to any function that does I/O or
   may block. Never start a goroutine without a plan for how it exits. Use
-  sync.WaitGroup or a done channel to manage lifetimes.
+  sync.WaitGroup or a done channel to manage lifetimes. Protect package-level
+  mutable state (global variables modified at runtime) with a sync.Mutex or
+  sync.RWMutex. Document that a variable requires locking and provide paired
+  getter/setter functions rather than exposing the variable directly.
 
 testing: |
   Every exported function and every meaningful branch deserves a test. Use
-  table-driven parameterized tests for similar cases. Each row is one scenario
-  with named inputs and expected outputs. Extract shared setup into test helpers.
-  Build reusable test utilities in a testutil package. When writing tests, ask
-  what inputs break assumptions: zero values, nil pointers, empty slices,
-  duplicate keys, boundary lengths, concurrent access. If a bug could hide there,
-  write a case for it.
+  table-driven parameterized tests for similar cases. The canonical structure is
+  a slice of anonymous structs with a name field, run with t.Run:
+
+    tests := []struct {
+      name  string
+      input string
+      want  int
+    }{
+      {"empty", "", 0},
+      {"one line", "hello\n", 1},
+    }
+    for _, tc := range tests {
+      t.Run(tc.name, func(t *testing.T) {
+        got := countLines(tc.input)
+        require.Equal(t, tc.want, got)
+      })
+    }
+
+  Call t.Parallel() as the first line of every test function that is safe to
+  run concurrently. A test is safe to parallelize when it writes only to its own
+  t.TempDir(), spawns isolated subprocesses, and does not call os.Chdir() or
+  mutate package-level global state. Do NOT call t.Parallel() in tests that call
+  os.Chdir() or any function that changes the process working directory — exec.Command
+  calls without cmd.Dir observe the process cwd, so a parallel os.Chdir() will
+  corrupt other tests running concurrently. In table-driven tests, add t.Parallel()
+  inside each t.Run subtest when the rows are independent.
+
+  Call t.Helper() as the first line of every test helper function. This causes
+  test failures to point to the caller site, not the helper internals:
+
+    func writeFile(t *testing.T, path, content string) {
+      t.Helper()
+      require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+    }
+
+  Use TestMain(m *testing.M) when the package requires one-time setup — compiling
+  a test binary, creating a shared fixture directory — that must complete before
+  any test runs. Call os.Exit(m.Run()) at the end. Do not use TestMain for
+  per-test setup; use t.Cleanup or helper functions for that.
+
+  Extract shared setup into helper functions. Build reusable test utilities in a
+  testutil package. When writing tests, ask what inputs break assumptions: zero
+  values, nil pointers, empty slices, duplicate keys, boundary lengths. If a bug
+  could hide there, write a case for it.
 
 code_review_checklist:
   - "No duplicated logic exists that could be extracted into a shared function or struct."
-  - "No magic strings remain: all binaries, paths, and repeated text are centralized."
+  - "No magic strings remain: all binaries, paths, and repeated text are centralized as named constants."
   - "Every error is handled or explicitly discarded with a comment."
   - "Every struct has a single, nameable responsibility."
   - "No function exceeds 200 lines without a strong reason."
-  - "Interfaces are small (one to three methods) and have at least two implementations or a testing need."
+  - "Every sub-package boundary has an interface. Interfaces are small (one to three methods)."
   - "No boolean parameters toggle behavior that should be a Strategy or Decorator."
   - "Config structs embed shared fields rather than duplicating them."
   - "context.Context is threaded through I/O paths."
   - "Tests cover the contract, not the implementation."
+  - "Every test function that is safe to parallelize calls t.Parallel() as its first line."
+  - "No test calls t.Parallel() if it uses os.Chdir() or mutates package-level global state."
+  - "Every test helper calls t.Helper() as its first line."
+  - "All receiver names are one- or two-letter abbreviations, consistent across all methods of the type."
+  - "Imports are grouped: stdlib, external, internal — each group separated by a blank line."
+  - "Every exported symbol has a godoc comment starting with the symbol name."
+  - "No os.Getenv() call controls orchestrator behaviour, execution mode, file paths, or any option that belongs in configuration.yaml."
+  - "No init() function performs I/O or returns an error."
+  - "No panic() is reachable from a runtime condition or user-provided input."
+  - "Typed iota enums are used for any fixed set of integer values."
+  - "All source files are written before running build or test commands — no incremental compile-fix loops."
 
 sections:
   - tag: copyright_header
@@ -213,69 +397,140 @@ sections:
       Search for existing code before writing a new function. Extract shared
       logic at the two-occurrence threshold — if you write the same thing twice,
       extract it.
+  - tag: implementation_strategy
+    title: Implementation Strategy
+    content: |
+      Write all source files before running any build or test commands. Plan
+      the full implementation, write each file in dependency order, then
+      compile and test once. This avoids incremental compile-fix loops that
+      waste turns re-sending the entire prompt context.
   - tag: design_patterns
     title: Design Patterns
     content: |
-      Six patterns apply: Strategy, Command, Facade, Factory, Decorator, and
-      Adapter. Select patterns to eliminate if/else ladders and centralize
-      construction logic.
+      Eight patterns apply: Strategy, Command, Facade, Factory, Decorator,
+      Builder, Adapter, and Observer. Select patterns to eliminate if/else ladders
+      and centralize construction logic.
   - tag: interfaces
     title: Interfaces
     content: |
-      Introduce an interface only when two concrete implementations exist or a
-      dependency must be mocked in tests. Accept interfaces as parameters;
-      return concrete structs. Keep interfaces small: one to three methods.
+      Every boundary between a parent package and its internal sub-packages
+      must be defined by an interface, even when only one implementation exists.
+      Accept interfaces as parameters; return concrete structs. Keep interfaces
+      small: one to three methods.
   - tag: struct_and_function_design
     title: Struct and Function Design
     content: |
       Each struct represents one concept; each function does one thing. Group
       more than three parameters into a config struct. Split functions exceeding
-      40 lines at a natural seam.
+      200 lines at a natural seam.
+  - tag: receiver_conventions
+    title: Receiver Conventions
+    content: |
+      Use pointer receivers for stateful or large types, value receivers for small
+      immutable types. All methods on a type use the same receiver kind. Name
+      receivers with a one- or two-letter abbreviation of the type; never use
+      self or this.
   - tag: error_handling
     title: Error Handling
     content: |
       Handle errors at the point they occur with guard clauses. Wrap errors with
       context using fmt.Errorf. Never silently discard an error except for
       best-effort cleanup, and always leave a comment when discarding.
+  - tag: panic_vs_error
+    title: Panic vs Error
+    content: |
+      Return errors for runtime conditions. Use panic only for programming
+      contract violations. Never panic on I/O failures or user-provided input.
+  - tag: init_functions
+    title: init() Usage
+    content: |
+      Avoid init(). Use it only for side-effect registration (drivers, codecs)
+      or infallible package-level lookup tables. Any initialization that can fail
+      must use an explicit function called from main() or a constructor.
   - tag: no_magic_strings
     title: No Magic Strings
     content: |
       Centralize all string literals for binary names, file paths, URLs, and
       repeated text as named constants. Never scatter raw string literals.
+  - tag: configuration_via_yaml
+    title: Configuration via YAML Only
+    content: |
+      All configuration flows through configuration.yaml and the Config struct.
+      Do not use os.Getenv() to control orchestrator behaviour, execution modes,
+      or any option that belongs in configuration.yaml. os.Getenv() is
+      permitted only for platform context (HOME, PATH) and, in test code, for
+      variables the test harness itself sets.
+
+  - tag: constants
+    title: Constants and Iota
+    content: |
+      Use typed constants for fixed sets of values. Use iota for sequential
+      integer enums. Group related constants in a single const block. Keep
+      constants unexported unless callers outside the package need them.
   - tag: project_structure
     title: Project Structure
     content: |
       cmd/ for entry points, internal/ for private implementation, pkg/ for
-      public shared types, tests/ for integration tests, magefiles/ for build
-      tooling. Align package structure to SRD component structure.
+      public API surface, tests/ for integration tests, magefiles/ for build
+      tooling. Every package organizes implementation into internal/
+      sub-packages by domain concept. The parent package exports types and
+      delegates; internal sub-packages provide the implementation.
+  - tag: file_organization
+    title: File Organization
+    content: |
+      Name files by concern, not by kind (no types.go, helpers.go, utils.go).
+      Within a file: constants and types, then constructors, then exported
+      symbols, then unexported helpers, then main(). Tests go in <file>_test.go.
+  - tag: import_organization
+    title: Import Organization
+    content: |
+      Three import groups separated by blank lines: stdlib, external modules,
+      internal packages. No dot imports except by established test convention.
+      No blank imports except for driver/codec side-effect registration.
   - tag: standard_packages
     title: Standard Packages
     content: |
       Approved dependencies: mage for build automation, cobra for CLI, viper for
       configuration, testify for test assertions, yaml.v3 for YAML parsing, and
       encoding/json from the standard library.
+  - tag: struct_embedding
+    title: Struct Embedding
+    content: |
+      Extract shared fields into a common struct and embed it. Provide
+      registerXxxFlags helpers for embedded CLI flag groups.
   - tag: naming_conventions
     title: Naming Conventions
     content: |
-      Exported names use CamelCase; unexported use camelCase. CLI flags use
+      Exported names use PascalCase; unexported use camelCase. CLI flags use
       kebab-case. Binary constants use the binXxx prefix. Factories use NewXxx.
-      Interfaces are named to describe behavior, not implementation.
+      Interfaces are named to describe behavior. Receivers use a one- or
+      two-letter abbreviation of the type. Test helpers use verb names.
+  - tag: comment_style
+    title: Comment Style
+    content: |
+      Every exported symbol has a godoc comment starting with the symbol name.
+      Unexported functions need comments only for non-obvious logic. Comments
+      explain why, not what. Reference requirement IDs when implementing a
+      specific requirement.
   - tag: concurrency
     title: Concurrency
     content: |
-      Use sync.Mutex for shared mutable state. Avoid global variables accessed
-      from goroutines. Thread context.Context through all I/O paths.
+      Thread context.Context through all I/O paths. Protect package-level mutable
+      state with sync.Mutex. Never start a goroutine without a plan for exit.
   - tag: testing
     title: Testing
     content: |
-      Write table-driven tests using t.Run subtests. Use testify assertions.
-      Mock external dependencies via interfaces. Tests cover contract, not
-      implementation; include edge cases, boundary lengths, and concurrent access.
+      Use table-driven tests with named struct rows and t.Run. Call t.Parallel()
+      at the top of every test safe to run concurrently — but never in tests that
+      call os.Chdir() or mutate global state. Call t.Helper() at the top of every
+      test helper function. Use TestMain for one-time package setup. Tests cover
+      the contract, not the implementation.
   - tag: code_review_checklist
     title: Code Review Checklist
     content: |
-      Before closing, verify: no duplicated logic, no magic strings, every error
-      handled or discarded with a comment, single-responsibility structs,
-      functions under 200 lines, small interfaces with at least two
-      implementations, no boolean-toggle parameters, and tests covering the
-      contract.
+      Before closing: no duplicated logic, no magic strings, every error handled
+      or discarded with a comment, single-responsibility structs, functions under
+      200 lines, small interfaces, no boolean-toggle parameters, t.Parallel() on
+      all safe tests, t.Helper() on all helpers, imports grouped, every exported
+      symbol documented, no init() with I/O, no panic on runtime conditions,
+      typed iota enums for fixed value sets.

--- a/docs/constitutions/go-style.yaml
+++ b/docs/constitutions/go-style.yaml
@@ -143,7 +143,7 @@ project_structure: |
   magefiles/: Build tooling. Flat directory (mage constraint). One file per
   concern.
 
-  Align package structure to PRD component structure. Each major component maps
+  Align package structure to SRD component structure. Each major component maps
   to one package. Avoid package names like util, common, helpers. Name packages
   by domain: storage, auth, config.
 
@@ -247,7 +247,7 @@ sections:
     content: |
       cmd/ for entry points, internal/ for private implementation, pkg/ for
       public shared types, tests/ for integration tests, magefiles/ for build
-      tooling. Align package structure to PRD component structure.
+      tooling. Align package structure to SRD component structure.
   - tag: standard_packages
     title: Standard Packages
     content: |

--- a/docs/constitutions/interface.yaml
+++ b/docs/constitutions/interface.yaml
@@ -1,0 +1,136 @@
+# Interface Constitution
+#
+# This constitution governs the definition, naming, and traceability of
+# interfaces in the architecture and SRDs. It is scaffolded into consuming
+# projects so Claude knows how to write well-formed interface specifications
+# and how SRDs reference interfaces.
+
+articles:
+  - id: I1
+    title: Interfaces live in ARCHITECTURE.yaml with optional specification files
+    rule: |
+      Every interface is declared in the interfaces section of
+      ARCHITECTURE.yaml. An interface groups related data structures and
+      operations under a name that components reference. Interfaces are not
+      declared in SRDs; SRDs reference interfaces defined in the architecture.
+
+      Each interface entry in ARCHITECTURE.yaml may include a spec_file field
+      pointing to a standalone specification file in docs/interfaces/. When
+      spec_file is present, the ARCHITECTURE.yaml entry is a summary and the
+      specification file is the authoritative contract. See
+      eng10-interface-specifications for the full format.
+
+  - id: I2
+    title: Required interface fields
+    rule: |
+      Every interface entry in ARCHITECTURE.yaml must have a name and a
+      summary. The name is a short, unique identifier (e.g., "Orchestrator
+      and Config", "Prompt Templates"). The summary describes what the
+      interface provides in one to three sentences. Optional fields are
+      data_structures (list of type names with brief descriptions),
+      operations (list of method or function signatures), and spec_file
+      (path to the full specification file).
+
+      Interface specification files in docs/interfaces/ must have id, name,
+      and summary. Optional fields are data_structures (with typed field
+      lists), operations (with typed parameters and returns), announcements,
+      and references.
+
+  - id: I3
+    title: Naming conventions
+    rule: |
+      Interface names use title case with spaces (e.g., "Generation
+      Lifecycle", "Issue Tracker"). Names must be unique within
+      ARCHITECTURE.yaml. Abbreviations are permitted when the abbreviation
+      is standard in the domain (e.g., "OOD" for object-oriented design),
+      but must be explained in the summary on first use.
+
+      Specification file names use kebab case matching the interface name:
+      ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml).
+
+  - id: I4
+    title: SRD interface references
+    rule: |
+      SRDs may declare interface relationships using two optional fields:
+      implemented_by and used_by. Both are lists of interface names that
+      must resolve to entries in ARCHITECTURE.yaml's interfaces section.
+
+      implemented_by declares that the SRD's requirements define the
+      implementation of the named interface. The SRD's package_contract
+      exports correspond to the interface's operations.
+
+      used_by declares that the SRD's implementation consumes the named
+      interface. The SRD depends on the interface being available but does
+      not define it.
+
+      A single SRD may appear in both lists for different interfaces. An
+      interface may be implemented by one SRD and used by many.
+
+  - id: I5
+    title: Port and adapter semantics
+    rule: |
+      Interfaces follow the ports and adapters pattern. The interface
+      declaration in ARCHITECTURE.yaml is the port: it defines the
+      contract without specifying implementation. SRDs that list the
+      interface in implemented_by are adapters: they provide a concrete
+      implementation of the port.
+
+      This separation means changing an adapter (rewriting a SRD's
+      implementation) does not change the port (the interface definition).
+      Consumers that reference the interface via used_by depend on the
+      port, not the adapter. Analysis enforces that every referenced
+      interface name resolves to a declared port.
+
+      When a specification file exists (spec_file), the port contract is
+      defined in that file using typed field lists for data structures and
+      typed parameter/return lists for operations. The ARCHITECTURE.yaml
+      entry remains the discovery point; the specification file is the
+      contract.
+
+  - id: I6
+    title: Interface traceability
+    rule: |
+      The traceability chain for interfaces runs: ARCHITECTURE.yaml
+      (declares the interface) -> specification file in docs/interfaces/
+      (defines the contract) -> SRD implemented_by (provides the
+      implementation) -> SRD used_by (consumes the interface). Analysis
+      validates both directions: every name in implemented_by and used_by
+      must match an interface name in ARCHITECTURE.yaml. Broken references
+      fail the analysis check.
+
+      Specification files include a references field listing SRD and use
+      case IDs that the interface traces to, completing the bidirectional
+      link.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six principles govern interface specifications: interfaces live in
+      ARCHITECTURE.yaml with optional specification files in docs/interfaces/
+      (I1), required fields are name and summary with spec_file as optional
+      (I2), names use title case and specification files use kebab case (I3),
+      SRDs reference interfaces via implemented_by and used_by (I4),
+      interfaces follow ports and adapters semantics (I5), and traceability
+      runs from architecture through specification files through SRDs (I6).
+  - tag: structure
+    title: Interface Structure
+    content: |
+      An interface entry in ARCHITECTURE.yaml is a YAML mapping with five
+      fields: name (required), summary (required), data_structures
+      (optional list), operations (optional list), and spec_file (optional
+      path). SRDs reference interfaces by name using implemented_by and
+      used_by string lists.
+
+      Specification files in docs/interfaces/ use typed field lists for
+      data structures and typed parameter/return lists for operations.
+      See eng10-interface-specifications for the full format.
+  - tag: validation
+    title: Analysis Validation
+    content: |
+      The mage analyze target validates interface references. Every entry
+      in a SRD's implemented_by and used_by lists must match the name
+      field of an interface in ARCHITECTURE.yaml. Unresolved references
+      are reported as errors. Missing or empty interface lists are not
+      errors; the fields are optional. When spec_file is present, analyze
+      can validate that the referenced file exists.

--- a/docs/constitutions/planning.yaml
+++ b/docs/constitutions/planning.yaml
@@ -50,29 +50,29 @@ articles:
   - id: P5
     title: Dependency ordering
     rule: |
-      Identify what should be built first and why. PRDs before use cases,
+      Identify what should be built first and why. SRDs before use cases,
       use cases before test suites, test suites before code, foundational code
       before features, libraries before CLI.
 
   - id: P6
     title: Requirement-anchored decomposition
     rule: |
-      Anchor each task to specific PRD requirements by ID (e.g., prd001 R1.1,
-      prd002 R2.3). Include the requirement ID(s) in the task title. Each PRD
+      Anchor each task to specific SRD requirements by ID (e.g., srd001 R1.1,
+      srd002 R2.3). Include the requirement ID(s) in the task title. Each SRD
       requirement maps to exactly one task unless the requirement exceeds the
       line budget, in which case split into implementation and test tasks that
       both reference the same requirement. Do not invent task boundaries that
       cross requirement boundaries. This makes decomposition deterministic:
-      given the same PRD and release, the same set of tasks should be proposed.
+      given the same SRD and release, the same set of tasks should be proposed.
 
   - id: P7
     title: File naming conventions
     rule: |
       Derive file names from the module or feature name established in the
-      PRD or architecture document. Use the existing project naming pattern
+      SRD or architecture document. Use the existing project naming pattern
       (snake_case for Go files, kebab-case for YAML documents). When creating
       a new package, use the name from ARCHITECTURE.yaml. Do not invent novel
-      file names. If the PRD names a component "crumb", the file is crumb.go,
+      file names. If the SRD names a component "crumb", the file is crumb.go,
       not item.go or entity.go. Go packages must name the primary source file
       after the primary exported type, not the package name.
       `testutils/testutils.go` is forbidden; if the primary type is
@@ -96,7 +96,7 @@ articles:
     rule: |
       Code tasks target 5-8 requirements, 5-8 acceptance criteria, and 3-5
       design decisions. Documentation tasks target 2-4 requirements and 3-5
-      acceptance criteria. Each PRD requirement maps to exactly one task
+      acceptance criteria. Each SRD requirement maps to exactly one task
       requirement. Do not inflate counts by splitting a single requirement
       into sub-bullets, and do not deflate counts by merging unrelated
       requirements. If a task falls outside these ranges, re-examine the
@@ -112,7 +112,7 @@ issue_structure:
     required_reading:
       required: true
       description: |
-        Files the agent must read before starting. List PRDs, ARCHITECTURE
+        Files the agent must read before starting. List SRDs, ARCHITECTURE
         sections, existing code, or upstream docs. This is mandatory for all
         issues.
 
@@ -147,7 +147,7 @@ issue_structure:
       format_rule:
         required: true
         description: |
-          The rule file that governs the output format (e.g., prd-format,
+          The rule file that governs the output format (e.g., srd-format,
           use-case-format, test-case-format, architecture-format,
           vision-format, specification-format, engineering-guideline-format).
 
@@ -155,7 +155,7 @@ issue_structure:
         required: false
         description: |
           List of sections the document must contain, per the format rule.
-          For PRD: Problem, Goals, Requirements, Non-Goals, Acceptance Criteria.
+          For SRD: Problem, Goals, Requirements, Non-Goals, Acceptance Criteria.
           For use case: Summary, Actor/trigger, Flow, Success criteria.
 
     deliverable_types:
@@ -164,10 +164,10 @@ issue_structure:
         format_rule: architecture-format
         when: Updating system overview, components, design decisions
 
-      - type: PRD
-        location: "docs/specs/product-requirements/prd[NNN]-[feature-name].yaml"
-        format_rule: prd-format
-        when: New or updated product requirements
+      - type: SRD
+        location: "docs/specs/software-requirements/srd[NNN]-[feature-name].yaml"
+        format_rule: srd-format
+        when: New or updated software requirements
 
       - type: Use case
         location: "docs/specs/use-cases/rel[NN].[N]-uc[NNN]-[short-name].yaml"
@@ -187,7 +187,7 @@ issue_structure:
       - type: Specification
         location: docs/SPECIFICATIONS.md
         format_rule: specification-format
-        when: Summary of PRDs, use cases, test suites, roadmap
+        when: Summary of SRDs, use cases, test suites, roadmap
 
   yaml_quality:
     - Use ASCII dashes (--), not Unicode em dashes or en dashes.
@@ -195,21 +195,21 @@ issue_structure:
 
   code_issues:
     rules:
-      - No PRD-style Problem/Goals/Non-Goals sections in code issues
+      - No SRD-style Problem/Goals/Non-Goals sections in code issues
       - "Requirements focus on implementation: interfaces, operations, tests"
-      - Design decisions reference PRDs and architecture patterns
+      - Design decisions reference SRDs and architecture patterns
       - Acceptance criteria include tests passing and behavior verified
 
 example_documentation_issue: |
   deliverable_type: documentation
-  format_rule: prd-format
+  format_rule: srd-format
 
   required_reading:
     - docs/ARCHITECTURE.yaml (components section)
-    - docs/specs/product-requirements/prd001-hello-world-binary.yaml
+    - docs/specs/software-requirements/srd001-hello-world-binary.yaml
 
   files:
-    - path: docs/specs/product-requirements/prd-feature-name.yaml
+    - path: docs/specs/software-requirements/srd-feature-name.yaml
       action: create
 
   required_sections:
@@ -223,7 +223,7 @@ example_documentation_issue: |
     - id: AC1
       text: All required sections present
     - id: AC2
-      text: File saved as prd-feature-name.yaml
+      text: File saved as srd-feature-name.yaml
     - id: AC3
       text: Requirements numbered and specific
 
@@ -231,7 +231,7 @@ example_code_issue: |
   deliverable_type: code
 
   required_reading:
-    - docs/specs/product-requirements/prd003-crumbs-interface.yaml
+    - docs/specs/software-requirements/srd003-crumbs-interface.yaml
     - cmd/sdd-hello-world/main.go
 
   files:
@@ -247,7 +247,7 @@ example_code_issue: |
 
   requirements:
     - id: R1
-      text: Implement CrumbTable interface per prd003-crumbs-interface
+      text: Implement CrumbTable interface per srd003-crumbs-interface
     - id: R2
       text: Add, Get, Archive, Purge, Fetch operations
     - id: R3
@@ -255,9 +255,9 @@ example_code_issue: |
 
   design_decisions:
     - id: D1
-      text: Follow binary structure from prd001-hello-world-binary
+      text: Follow binary structure from srd001-hello-world-binary
     - id: D2
-      text: Filter as map[string]any per PRD
+      text: Filter as map[string]any per SRD
 
   acceptance_criteria:
     - id: AC1
@@ -265,7 +265,7 @@ example_code_issue: |
     - id: AC2
       text: Tests pass for each operation
     - id: AC3
-      text: Errors match PRD error types
+      text: Errors match SRD error types
 
 sections:
   - tag: articles
@@ -285,7 +285,7 @@ sections:
     title: Documentation Issue Example
     content: |
       A worked example shows a properly structured documentation issue for
-      writing a PRD, including required reading, output path, format rule, and
+      writing a SRD, including required reading, output path, format rule, and
       acceptance criteria.
   - tag: example_code_issue
     title: Code Issue Example

--- a/docs/constitutions/planning.yaml
+++ b/docs/constitutions/planning.yaml
@@ -13,6 +13,12 @@ articles:
       99.0 (unscheduled). Early preview of later use cases is allowed when they
       share functionality with the current release.
 
+      Use cases in road-map.yaml carry a status field. Use cases with
+      status "implemented" or "done" have existing code and are complete.
+      Do not propose any new tasks for them. Propose tasks only for use
+      cases with status "spec_complete", "pending", or any other value
+      that is not "implemented" or "done".
+
   - id: P2
     title: Task sizing
     rule: |
@@ -167,7 +173,7 @@ issue_structure:
       - type: SRD
         location: "docs/specs/software-requirements/srd[NNN]-[feature-name].yaml"
         format_rule: srd-format
-        when: New or updated software requirements
+        when: New or updated product requirements
 
       - type: Use case
         location: "docs/specs/use-cases/rel[NN].[N]-uc[NNN]-[short-name].yaml"
@@ -206,7 +212,7 @@ example_documentation_issue: |
 
   required_reading:
     - docs/ARCHITECTURE.yaml (components section)
-    - docs/specs/software-requirements/srd001-hello-world-binary.yaml
+    - docs/specs/software-requirements/srd001-cupboard-core.yaml
 
   files:
     - path: docs/specs/software-requirements/srd-feature-name.yaml
@@ -232,7 +238,7 @@ example_code_issue: |
 
   required_reading:
     - docs/specs/software-requirements/srd003-crumbs-interface.yaml
-    - cmd/sdd-hello-world/main.go
+    - pkg/types/cupboard.go
 
   files:
     - path: pkg/types/crumb.go
@@ -255,7 +261,7 @@ example_code_issue: |
 
   design_decisions:
     - id: D1
-      text: Follow binary structure from srd001-hello-world-binary
+      text: Use table accessor pattern from srd001-cupboard-core
     - id: D2
       text: Filter as map[string]any per SRD
 

--- a/docs/engineering/eng10-interface-specifications.yaml
+++ b/docs/engineering/eng10-interface-specifications.yaml
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: eng10-interface-specifications
+title: Interface Specification Format
+
+introduction: |
+  Interfaces in ARCHITECTURE.yaml serve as summaries: a name, a paragraph
+  of prose, and optional lists of data structures and operations written in
+  Go-specific notation. This works for orientation but breaks down when
+  tooling needs to validate contracts, generate stubs, or check that a SRD's
+  implemented_by claim actually matches the interface it references.
+
+  We introduce a standalone interface specification file format that lives in
+  docs/interfaces/. Each file is a self-contained YAML document with typed
+  field lists for data structures and a typed operations list for methods.
+  ARCHITECTURE.yaml retains the summary entries and gains a spec_file field
+  pointing to the full specification. The interface constitution (I1-I6)
+  governs both the summary and the specification file.
+
+sections:
+  - title: File Location and Naming
+    content: |
+      Interface specification files live in docs/interfaces/ and follow the
+      naming pattern ifc-[kebab-case-name].yaml, where the name matches the
+      interface name in ARCHITECTURE.yaml converted to kebab case. For
+      example, the "Generation Lifecycle" interface becomes
+      ifc-generation-lifecycle.yaml.
+
+      ARCHITECTURE.yaml interface entries gain an optional spec_file field
+      that points to the specification file path relative to the repository
+      root. When spec_file is present, the ARCHITECTURE.yaml entry is a
+      summary; the specification file is the authoritative contract.
+
+  - title: File Structure
+    content: |
+      Every interface specification file has four top-level fields:
+
+      Table: Interface specification fields
+
+      | Field | Required | Description |
+      |-------|----------|-------------|
+      | id | yes | Matches filename without extension (e.g., ifc-generation-lifecycle) |
+      | name | yes | Interface name, must match the ARCHITECTURE.yaml entry |
+      | summary | yes | One to three sentences describing the interface contract |
+      | data_structures | no | List of typed data structure definitions with field lists |
+      | operations | no | List of method definitions with typed parameters and returns |
+      | announcements | no | List of events or signals the interface emits |
+      | references | no | List of SRD or use case IDs this interface traces to |
+
+  - title: Data Structure Definitions
+    content: |
+      Each entry in data_structures is a YAML mapping with three fields:
+      name (the type name), description (one sentence), and fields (a list
+      of typed field definitions).
+
+      Each field has name, type, and an optional description. The type uses
+      language-agnostic names: string, integer, number, boolean, array, and
+      object. Add a required field set to true for fields that must be
+      present. Fields without required default to optional. Reference other
+      data structures defined in the same file by using their name as the
+      type.
+
+      Example:
+
+      ```yaml
+      data_structures:
+        - name: DiffStat
+          description: Parsed output from a git diff --shortstat command.
+          fields:
+            - name: files_changed
+              type: integer
+              description: Number of files changed.
+              required: true
+            - name: insertions
+              type: integer
+              description: Lines added.
+              required: true
+            - name: deletions
+              type: integer
+              description: Lines removed.
+              required: true
+      ```
+
+      Nested structures use object as the type with a nested fields list,
+      or reference another data structure by name:
+
+      ```yaml
+      fields:
+        - name: diff
+          type: DiffStat
+          description: Aggregate diff statistics.
+      ```
+
+  - title: Operation Definitions
+    content: |
+      Each entry in operations is a YAML mapping with four fields: name (the
+      method name), description (one sentence), parameters (list of typed
+      parameters), and returns (list of typed return values). Parameters and
+      returns each have name, type, and an optional description.
+
+      Types in parameters and returns use the same language-agnostic names
+      (string, integer, boolean, object, array) or reference data structures
+      defined in the same file by name. Use "void" when a method returns
+      nothing besides an error. Use "error" as the conventional error return
+      type.
+
+      Example:
+
+      ```yaml
+      operations:
+        - name: GeneratorStart
+          description: Tag base branch, create generation branch, and reset sources.
+          parameters: []
+          returns:
+            - name: error
+              type: error
+        - name: GeneratorRun
+          description: Run measure and stitch cycles until all issues are closed.
+          parameters:
+            - name: cycles
+              type: integer
+              description: Maximum number of cycles to execute.
+          returns:
+            - name: error
+              type: error
+      ```
+
+  - title: Versioning and Evolution
+    content: |
+      Interface specifications are versioned through git like all other
+      documentation. When an interface changes, update both the specification
+      file and the ARCHITECTURE.yaml summary. The spec_file field in
+      ARCHITECTURE.yaml serves as the link between the summary and the full
+      contract.
+
+      Breaking changes (removing operations, changing parameter types) should
+      be documented in the specification file's summary or in a design
+      decision in ARCHITECTURE.yaml.
+
+  - title: Relationship to mage analyze
+    content: |
+      The analyze target validates that every interface name in a SRD's
+      implemented_by and used_by lists resolves to an entry in
+      ARCHITECTURE.yaml's interfaces section (I6). When spec_file is
+      present, analyze can optionally validate that the specification file
+      exists at the declared path. Full schema validation of specification
+      file contents is a future extension.

--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -4,7 +4,7 @@ role: |
 task: |
   Follow these steps in order. Complete each step before moving to the next. Do NOT explore the filesystem, read files, or run commands unless a step explicitly asks you to. All project information is already provided in the project_context field above.
 
-  1. **Analyze project context** — Review the project_context field above. It contains ALL project documentation: vision, architecture, specifications, roadmap, PRDs, use cases, test suites, engineering guidelines, constitutions, and existing issues. Do NOT read any files — everything you need is inline.
+  1. **Analyze project context** — Review the project_context field above. It contains ALL project documentation: vision, architecture, specifications, roadmap, SRDs, use cases, test suites, engineering guidelines, constitutions, and existing issues. Do NOT read any files — everything you need is inline.
 
   2. **Summarize project state** — Write a brief summary of:
      - What problem this project solves
@@ -34,12 +34,12 @@ constraints: |
   - Each task MUST be independently executable by an agent that has no context beyond the task description and the execution constitution.
   - Do NOT assume the stitch agent has access to your analysis, the existing issues list, or any context from this conversation.
   - Do NOT propose tasks that require human judgment or manual testing. Each task must have checkable acceptance criteria.
-  - Anchor every task to specific PRD requirement IDs (e.g., prd001 R1.1). Include the requirement ID in the task title. Given the same PRD and release, the same tasks should be proposed regardless of how many times this prompt is run.
+  - Anchor every task to specific SRD requirement IDs (e.g., srd001 R1.1). Include the requirement ID in the task title. Given the same SRD and release, the same tasks should be proposed regardless of how many times this prompt is run.
   - Order tasks canonically: documentation before code, types before implementations, libraries before consumers, implementation before tests. Break ties by primary file path alphabetically.
-  - Derive file names from PRD/architecture names, not invented names. If the architecture calls a component "crumb", the file is crumb.go.
-  - Do NOT invent design decisions not derived from the PRD or architecture. Derive struct shapes, timeout strategies, file names, and naming conventions from the PRD rather than making arbitrary choices. If the PRD does not specify a detail, omit it from design decisions rather than inventing one.
-  - When a PRD specifies a concrete design choice (e.g., "use a FileExpectation struct", "the main file is difftest.go", "timeout is configurable via context"), copy that choice verbatim into the task's design_decisions. Do not rephrase, generalize, or substitute alternatives. The PRD is the single source of truth for implementation details.
-  - Do NOT vary requirement count between equivalent runs. Each PRD requirement maps to one task requirement. Given the same input, produce the same requirement set. If two runs of this prompt against the same project state would produce different requirements, the decomposition is under-constrained -- tighten it.
+  - Derive file names from SRD/architecture names, not invented names. If the architecture calls a component "crumb", the file is crumb.go.
+  - Do NOT invent design decisions not derived from the SRD or architecture. Derive struct shapes, timeout strategies, file names, and naming conventions from the SRD rather than making arbitrary choices. If the SRD does not specify a detail, omit it from design decisions rather than inventing one.
+  - When a SRD specifies a concrete design choice (e.g., "use a FileExpectation struct", "the main file is difftest.go", "timeout is configurable via context"), copy that choice verbatim into the task's design_decisions. Do not rephrase, generalize, or substitute alternatives. The SRD is the single source of truth for implementation details.
+  - Do NOT vary requirement count between equivalent runs. Each SRD requirement maps to one task requirement. Given the same input, produce the same requirement set. If two runs of this prompt against the same project state would produce different requirements, the decomposition is under-constrained -- tighten it.
   - Do NOT make any tool calls. Return the YAML list directly in your text output.
 
 output_format: |
@@ -56,7 +56,7 @@ output_format: |
 
         required_reading:
           - path/to/file.go (reason this file must be read)
-          - docs/specs/product-requirements/prd001-feature.yaml
+          - docs/specs/software-requirements/srd001-feature.yaml
 
         files:
           - path: pkg/types/example.go
@@ -68,13 +68,13 @@ output_format: |
 
         requirements:
           - id: R1
-            text: Implement ExampleType per prd001-feature R2
+            text: Implement ExampleType per srd001-feature R2
           - id: R2
             text: Add Get and Set operations
 
         design_decisions:
           - id: D1
-            text: Follow binary structure from prd001-hello-world-binary
+            text: Follow binary structure from srd001-hello-world-binary
           - id: D2
             text: "Keep implementation in internal/, not pkg/"
 
@@ -108,6 +108,6 @@ output_format: |
 
   The description must be self-contained. All five fields (deliverable_type, required_reading, files, requirements, acceptance_criteria) are required. Each requirement, design_decision, and acceptance_criteria entry is a mapping with `id` and `text` fields. Add design_decisions when the stitch agent must follow specific patterns or architecture constraints.
 
-  When a golden_example field is present in this prompt, it is the authoritative reference for style, granularity, and naming conventions. Match its requirement count range, acceptance criteria density, design decision style, and file naming pattern. Deviate from the golden example only when the PRD explicitly requires a different structure.
+  When a golden_example field is present in this prompt, it is the authoritative reference for style, granularity, and naming conventions. Match its requirement count range, acceptance criteria density, design decision style, and file naming pattern. Deviate from the golden example only when the SRD explicitly requires a different structure.
 
   The orchestrator will parse the YAML from your text output and import the tasks into the issue tracker.

--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -20,32 +20,25 @@ task: |
 
   4. **Propose tasks** — For each task, write a description that follows the crumb-format YAML schema (see planning_constitution above and output_format below). Remember: the stitch agent sees ONLY the task description and the execution constitution. It does not see your analysis, the existing issues, or this conversation. The description must be self-contained.
 
-  5. **Return output** — Return the proposed tasks as a YAML list in your text output, inside a fenced code block marked ```yaml. Do NOT use any tools. Your entire response is text only.
+  5. **Write output** — Append the proposed tasks as a YAML list to `{output_path}` using the Write tool.
 
 constraints: |
-  - Do NOT use any tools. Do NOT explore the filesystem, read files, or run commands. All project information is in the project_context above. Your response must be text only with zero tool calls.
-  - Do NOT interact with the issue tracker directly.
+  - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands. Do NOT read files. All project information is in the project_context above.
+  - Do NOT interact with the issue tracker directly. Write the tasks to `{output_path}` using the Write tool.
+  - Do NOT read docs/ files with tools. All documentation is provided in the project_context above.
   - Do NOT duplicate existing issues. Review the issues in the project_context above before proposing.
-  - Issues with status "closed" represent COMPLETED work. Do not re-propose work that a closed issue already covers, even under a different title or framing. The completed_work field in project_context lists all finished tasks — treat every entry as work that must not be repeated.
-  - When source_code contains .go files for a package, that package already exists. Do not propose creating or reimplementing it. Trust the source code over prose descriptions in documentation (e.g., implementation_status sections in ARCHITECTURE.yaml may be stale).
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.
-  - Each task must contain at most {max_requirements} requirements. Split any task that would exceed this limit.
+  - SRD requirements use a two-level structure: R-groups (R1, R2, R3) contain sub-requirements (R1.1, R1.2, R2.1). When referencing requirements, always use sub-requirement IDs (e.g., "srd003 R2.1, R2.2, R2.3"), not group IDs. A reference to "srd003 R2" means ALL sub-requirements under R2, which may be 10+ items. Each task must contain at most {max_requirements} SRD sub-requirements total. Count every sub-requirement individually: "srd003 R2.1, R2.2, R2.3" is 3 sub-requirements, while "srd003 R2" expands to however many items R2 contains. Split tasks that would exceed the limit.
   - Each task MUST be independently executable by an agent that has no context beyond the task description and the execution constitution.
   - Do NOT assume the stitch agent has access to your analysis, the existing issues list, or any context from this conversation.
   - Do NOT propose tasks that require human judgment or manual testing. Each task must have checkable acceptance criteria.
-  - Anchor every task to specific SRD requirement IDs (e.g., srd001 R1.1). Include the requirement ID in the task title. Given the same SRD and release, the same tasks should be proposed regardless of how many times this prompt is run.
-  - Order tasks canonically: documentation before code, types before implementations, libraries before consumers, implementation before tests. Break ties by primary file path alphabetically.
-  - Derive file names from SRD/architecture names, not invented names. If the architecture calls a component "crumb", the file is crumb.go.
-  - Do NOT invent design decisions not derived from the SRD or architecture. Derive struct shapes, timeout strategies, file names, and naming conventions from the SRD rather than making arbitrary choices. If the SRD does not specify a detail, omit it from design decisions rather than inventing one.
-  - When a SRD specifies a concrete design choice (e.g., "use a FileExpectation struct", "the main file is difftest.go", "timeout is configurable via context"), copy that choice verbatim into the task's design_decisions. Do not rephrase, generalize, or substitute alternatives. The SRD is the single source of truth for implementation details.
-  - Do NOT vary requirement count between equivalent runs. Each SRD requirement maps to one task requirement. Given the same input, produce the same requirement set. If two runs of this prompt against the same project state would produce different requirements, the decomposition is under-constrained -- tighten it.
-  - Do NOT make any tool calls. Return the YAML list directly in your text output.
+  - The ONLY tool call you should make is the Write tool to save the output YAML file.
 
 output_format: |
-  Return a YAML list of crumb objects inside a fenced code block (```yaml). Each crumb has a sequential `index` (starting at 0) and a `dependency` field. Set `dependency` to the index of the crumb that must be completed first, or `-1` if there are no dependencies.
+  Write a YAML list of crumb objects to `{output_path}`. Each crumb has a sequential `index` (starting at 0) and a `dependency` field. Set `dependency` to the index of the crumb that must be completed first, or `-1` if there are no dependencies.
 
-  The `description` field must be a valid YAML document conforming to the issue_format_constitution injected above. Write it as a YAML literal block scalar. Use ASCII dashes, not Unicode em dashes. Requirements, design decisions, and acceptance criteria are all mappings with `id:` and `text:` fields (R1/R2/..., D1/D2/..., AC1/AC2/...).
+  The `description` field must follow the crumb-format YAML schema from the planning_constitution. Write it as a YAML literal block scalar.
 
   Example:
     - index: 0
@@ -67,22 +60,17 @@ output_format: |
             note: ExampleType implementation
 
         requirements:
-          - id: R1
-            text: Implement ExampleType per srd001-feature R2
-          - id: R2
-            text: Add Get and Set operations
+          - "R1: Implement ExampleType struct per srd001-feature R2.1, R2.2"
+          - "R2: Add Get operation per srd001-feature R2.3"
+          - "R3: Add Set operation per srd001-feature R2.4"
 
         design_decisions:
-          - id: D1
-            text: Follow binary structure from srd001-hello-world-binary
-          - id: D2
-            text: "Keep implementation in internal/, not pkg/"
+          - Use table accessor pattern from srd001-cupboard-core
+          - "Keep implementation in internal/, not pkg/"
 
         acceptance_criteria:
-          - id: AC1
-            text: All operations implemented and tested
-          - id: AC2
-            text: Tests pass for each operation
+          - All operations implemented and tested
+          - Tests pass for each operation
 
     - index: 1
       title: Task that depends on task 0
@@ -99,15 +87,11 @@ output_format: |
             note: integration tests
 
         requirements:
-          - id: R1
-            text: Test all ExampleType operations end to end
+          - "R1: Test all ExampleType operations end to end"
 
         acceptance_criteria:
-          - id: AC1
-            text: All tests pass
+          - All tests pass
 
-  The description must be self-contained. All five fields (deliverable_type, required_reading, files, requirements, acceptance_criteria) are required. Each requirement, design_decision, and acceptance_criteria entry is a mapping with `id` and `text` fields. Add design_decisions when the stitch agent must follow specific patterns or architecture constraints.
+  The description must be self-contained. All five fields (deliverable_type, required_reading, files, requirements, acceptance_criteria) are required. Add design_decisions when the stitch agent must follow specific patterns or architecture constraints.
 
-  When a golden_example field is present in this prompt, it is the authoritative reference for style, granularity, and naming conventions. Match its requirement count range, acceptance criteria density, design decision style, and file naming pattern. Deviate from the golden example only when the SRD explicitly requires a different structure.
-
-  The orchestrator will parse the YAML from your text output and import the tasks into the issue tracker.
+  The tasks will be automatically imported into the issue tracker.

--- a/docs/prompts/stitch.yaml
+++ b/docs/prompts/stitch.yaml
@@ -19,7 +19,7 @@ constraints: |
   - Do NOT read files already provided in project_context. They are already inline above.
   - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands.
   - Do NOT modify files outside the Files to Create/Modify list unless a requirement explicitly demands it.
-  - Do NOT interact with the issue tracker directly. Task tracking is handled externally via GitHub Issues.
+  - Do NOT use bd or cupboard commands. Task tracking is handled externally.
   - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or SRDs.
   - Do NOT add features, refactoring, or improvements beyond what the requirements specify.
   - Do NOT run any git commands. No git add, git commit, git init, git status, rm .git, or any other git operation. Git is managed externally by the orchestrator. Just write code and verify it compiles and passes tests.

--- a/docs/prompts/stitch.yaml
+++ b/docs/prompts/stitch.yaml
@@ -20,6 +20,6 @@ constraints: |
   - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands.
   - Do NOT modify files outside the Files to Create/Modify list unless a requirement explicitly demands it.
   - Do NOT interact with the issue tracker directly. Task tracking is handled externally via GitHub Issues.
-  - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or PRDs.
+  - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or SRDs.
   - Do NOT add features, refactoring, or improvements beyond what the requirements specify.
   - Do NOT run any git commands. No git add, git commit, git init, git status, rm .git, or any other git operation. Git is managed externally by the orchestrator. Just write code and verify it compiles and passes tests.

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -19,8 +19,8 @@ releases:
     name: Hello world binary from specifications
     status: pending
     description: |
-      We implement the hello world binary from its PRD specification. The
-      generation pipeline reads prd001-hello-world-binary and produces the Go
+      We implement the hello world binary from its SRD specification. The
+      generation pipeline reads srd001-hello-world-binary and produces the Go
       source files. This release validates that cobbler-scaffold can generate
       code from specs in a clean repository.
     use_cases:

--- a/docs/specs/software-requirements/srd001-hello-world-binary.yaml
+++ b/docs/specs/software-requirements/srd001-hello-world-binary.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Petar Djukic. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-id: prd001-hello-world-binary
+id: srd001-hello-world-binary
 title: Hello World Binary
 
 problem: |
@@ -9,7 +9,7 @@ problem: |
   measure and stitch pipeline against. The binary must be simple enough that a
   single generation cycle can produce it from specifications alone, yet
   complete enough to validate that the pipeline creates compilable, runnable
-  Go code. Without a PRD that specifies the binary's requirements, the measure
+  Go code. Without an SRD that specifies the binary's requirements, the measure
   agent has no anchored requirements to propose and proposes zero tasks.
 
 goals:

--- a/docs/specs/software-requirements/srd002-cli-enhancements.yaml
+++ b/docs/specs/software-requirements/srd002-cli-enhancements.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Petar Djukic. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-id: prd002-cli-enhancements
+id: srd002-cli-enhancements
 title: CLI Enhancements
 
 problem: |
@@ -10,7 +10,7 @@ problem: |
   pipeline completes in a single cycle. We need additional requirements that
   exercise multi-cycle generation: multiple use cases within a release, flag
   parsing, error handling, and version reporting. These requirements must use
-  only the Go standard library so the zero-dependency constraint from prd001
+  only the Go standard library so the zero-dependency constraint from srd001
   is preserved.
 
 goals:
@@ -37,7 +37,7 @@ requirements:
     items:
       - R2.1: The binary must accept a --name flag that takes a string argument.
       - R2.2: When --name is provided with a value, the binary must print "Hello, <value>!" followed by a newline to stdout, where <value> is the flag argument.
-      - R2.3: When --name is not provided, the binary must print "Hello, World!" followed by a newline to stdout (preserving prd001 R2.1 default behavior).
+      - R2.3: When --name is not provided, the binary must print "Hello, World!" followed by a newline to stdout (preserving srd001 R2.1 default behavior).
   R3:
     title: Help flag
     items:

--- a/docs/specs/software-requirements/srd003-config.yaml
+++ b/docs/specs/software-requirements/srd003-config.yaml
@@ -1,15 +1,15 @@
 # Copyright (c) 2026 Petar Djukic. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-id: prd003-config
+id: srd003-config
 title: Configuration File Support
 
 problem: |
   The hello world binary accepts flags for individual settings but has no way
-  to load multiple settings from a file. With only two PRDs and 17 R-items,
+  to load multiple settings from a file. With only two SRDs and 17 R-items,
   the cobbler-scaffold generation pipeline completes in two to three stitch
   cycles, which is too few to exercise cross-batch duplicate detection and
-  partial UC completion gating. We need a third PRD with enough R-items to
+  partial UC completion gating. We need a third SRD with enough R-items to
   require three or more stitch tasks, exercising the requirement tracking
   pipeline at scale. A JSON configuration file adds 12 R-items across four
   groups while preserving the zero-dependency constraint (encoding/json is
@@ -33,7 +33,7 @@ requirements:
     items:
       - R1.1: The binary must accept a --config flag that takes a file path argument.
       - R1.2: The binary must parse the config file as JSON with three optional string fields named "name", "template", and "format".
-      - R1.3: When --config is not provided, no config file is loaded and all behavior defaults apply as specified in prd001 and prd002.
+      - R1.3: When --config is not provided, no config file is loaded and all behavior defaults apply as specified in srd001 and srd002.
   R2:
     title: Config-driven behavior
     items:

--- a/docs/specs/use-cases/rel02.0-uc001-build-hello-world.yaml
+++ b/docs/specs/use-cases/rel02.0-uc001-build-hello-world.yaml
@@ -32,17 +32,17 @@ touchpoints:
   - id: T1
     text: |
       Binary component (cmd/sdd-hello-world/main.go) — exercises the main
-      function that prints the greeting. Implements prd001-hello-world-binary
+      function that prints the greeting. Implements srd001-hello-world-binary
       R1.1, R2.1, R2.2, R2.3.
   - id: T2
     text: |
       Version file (cmd/sdd-hello-world/version.go) — confirms the version
-      constant compiles alongside main.go. Implements prd001-hello-world-binary
+      constant compiles alongside main.go. Implements srd001-hello-world-binary
       R1.2.
   - id: T3
     text: |
       Go module (go.mod) — validates that the module builds with zero external
-      dependencies. Implements prd001-hello-world-binary R1.3.
+      dependencies. Implements srd001-hello-world-binary R1.3.
 
 success_criteria:
   - id: S1

--- a/docs/specs/use-cases/rel03.0-uc002-greeting-and-version.yaml
+++ b/docs/specs/use-cases/rel03.0-uc002-greeting-and-version.yaml
@@ -9,7 +9,7 @@ summary: |
   verify that flag parsing produces correct stdout output. The --version flag
   prints the Version constant. The --name flag personalizes the greeting.
   Running with no flags preserves the default "Hello, World!" behavior from
-  prd001. This use case exercises the stdout-producing flag paths.
+  srd001. This use case exercises the stdout-producing flag paths.
 
 actor: Developer or CI pipeline
 
@@ -38,12 +38,12 @@ touchpoints:
     text: |
       Binary component (cmd/sdd-hello-world/main.go) — exercises the flag
       parsing logic for --version and --name, and the default greeting path.
-      Implements prd002-cli-enhancements R1.1, R1.2, R1.3, R2.1, R2.2, R2.3.
+      Implements srd002-cli-enhancements R1.1, R1.2, R1.3, R2.1, R2.2, R2.3.
   - id: T2
     text: |
       Version file (cmd/sdd-hello-world/version.go) — the Version constant
       whose value is printed to stdout when --version is provided. Implements
-      prd002-cli-enhancements R1.1.
+      srd002-cli-enhancements R1.1.
 
 success_criteria:
   - id: S1

--- a/docs/specs/use-cases/rel03.0-uc003-help-and-errors.yaml
+++ b/docs/specs/use-cases/rel03.0-uc003-help-and-errors.yaml
@@ -36,7 +36,7 @@ touchpoints:
     text: |
       Binary component (cmd/sdd-hello-world/main.go) — exercises the --help
       usage output and the error handling path for unknown flags. Implements
-      prd002-cli-enhancements R3.1, R3.2, R4.1, R4.2, R4.3.
+      srd002-cli-enhancements R3.1, R3.2, R4.1, R4.2, R4.3.
 
 success_criteria:
   - id: S1

--- a/docs/specs/use-cases/rel04.0-uc004-config-loading.yaml
+++ b/docs/specs/use-cases/rel04.0-uc004-config-loading.yaml
@@ -48,7 +48,7 @@ touchpoints:
     text: |
       Binary component (cmd/sdd-hello-world/main.go) — exercises the config
       file loading, JSON parsing, template application, JSON output mode,
-      and flag precedence logic. Implements prd003-config R1.1, R1.2, R1.3,
+      and flag precedence logic. Implements srd003-config R1.1, R1.2, R1.3,
       R2.1, R2.2, R2.3, R3.1, R3.2, R3.3.
 
 success_criteria:

--- a/docs/specs/use-cases/rel04.0-uc005-config-validation.yaml
+++ b/docs/specs/use-cases/rel04.0-uc005-config-validation.yaml
@@ -39,7 +39,7 @@ touchpoints:
     text: |
       Binary component (cmd/sdd-hello-world/main.go) — exercises the config
       file error handling for missing files, malformed JSON, and unknown
-      fields. Implements prd003-config R4.1, R4.2, R4.3.
+      fields. Implements srd003-config R4.1, R4.2, R4.3.
 
 success_criteria:
   - id: S1

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260316.1
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260403.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260316.1 h1:m2JvTwu8N/80+WeYEU1KA3VzJ+7xVNgNbUnQk9AKoGs=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260316.1/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260403.0 h1:KI+dvlHOGBMluZrt5EjR8GHJFgWYxU5rUNo01+6THTg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260403.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/magefiles/orchestrator.go
+++ b/magefiles/orchestrator.go
@@ -29,9 +29,10 @@ type Prompt mg.Namespace
 type Stats mg.Namespace
 
 // Tests: run directly with go test:
-//   go test -tags=usecase -v -count=1 -timeout 1800s ./tests/rel01.0/...          # all
-//   go test -tags=usecase -v ./tests/rel01.0/uc001/                               # one UC
-//   go test -tags=usecase -bench=. -benchtime=1x -run=^$ ./tests/rel01.0/uc008/   # benchmarks
+//
+//	go test -tags=usecase -v -count=1 -timeout 1800s ./tests/rel01.0/...          # all
+//	go test -tags=usecase -v ./tests/rel01.0/uc001/                               # one UC
+//	go test -tags=usecase -bench=. -benchtime=1x -run=^$ ./tests/rel01.0/uc008/   # benchmarks
 
 // baseCfg holds the configuration loaded from configuration.yaml.
 var baseCfg orchestrator.Config
@@ -64,85 +65,100 @@ func logf(format string, args ...any) {
 // --- Top-level targets ---
 
 // Init initializes the project.
-func Init() error { return newOrch().Init() }
+func Init() error { return newOrch().Generator.Init() }
 
 // Reset performs a full reset: cobbler and generator.
-func Reset() error { return newOrch().FullReset() }
+func Reset() error { return newOrch().Generator.FullReset() }
 
 // Build compiles the project binary.
-func Build() error { return newOrch().Build() }
+func Build() error { return newOrch().Builder.Build() }
 
 // Lint runs golangci-lint on the project.
-func Lint() error { return newOrch().Lint() }
+func Lint() error { return newOrch().Builder.Lint() }
 
 // Install runs go install for the main package.
-func Install() error { return newOrch().Install() }
+func Install() error { return newOrch().Builder.Install() }
 
 // Clean removes build artifacts.
-func Clean() error { return newOrch().Clean() }
+func Clean() error { return newOrch().Builder.Clean() }
 
 // Credentials extracts Claude credentials from the macOS Keychain.
-func Credentials() error { return newOrch().ExtractCredentials() }
+func Credentials() error { return newOrch().Builder.ExtractCredentials() }
 
-// Analyze performs cross-artifact consistency checks (PRDs, use cases, test suites, roadmap).
-func Analyze() error { return newOrch().Analyze() }
+// Analyze performs cross-artifact consistency checks (SRDs, use cases, test suites, roadmap).
+func Analyze() error { return newOrch().Analyzer.Analyze() }
 
 // Tag creates a documentation release tag (v0.YYYYMMDD.N) and builds the container image.
-func Tag() error { return newOrch().Tag() }
+func Tag() error { return newOrch().Releaser.Tag() }
 
 // --- Scaffold targets ---
 
 // Pop removes orchestrator-managed files from the target repository:
 // magefiles/orchestrator.go, docs/constitutions/, docs/prompts/, and
 // configuration.yaml. Pass "." for the current directory.
-func (Scaffold) Pop(target string) error { return newOrch().Uninstall(target) }
+func (Scaffold) Pop(target string) error { return newOrch().Scaffolder.Uninstall(target) }
 
 // --- Cobbler targets ---
 
 // Measure assesses project state and proposes new tasks via Claude.
-func (Cobbler) Measure() error { return newOrch().Measure() }
+func (Cobbler) Measure() error { return newOrch().Measure.Measure() }
 
 // Stitch picks ready tasks and invokes Claude to execute them.
-func (Cobbler) Stitch() error { return newOrch().Stitch() }
+func (Cobbler) Stitch() error { return newOrch().Stitch.Stitch() }
 
 // Reset removes the cobbler scratch directory.
-func (Cobbler) Reset() error { return newOrch().CobblerReset() }
+func (Cobbler) Reset() error { return newOrch().ClaudeRunner.CobblerReset() }
 
 // --- Generator targets ---
 
 // Start begins a new generation trail.
-func (Generator) Start() error { return newOrch().GeneratorStart() }
+func (Generator) Start() error { return newOrch().Generator.GeneratorStart() }
 
 // Run executes measure + stitch cycles using the generation.cycles value in configuration.yaml.
 // Use RunN to override the cycle count for a single invocation.
-func (Generator) Run() error { return newOrch().GeneratorRun(0) }
+func (Generator) Run() error { return newOrch().Generator.GeneratorRun(0) }
 
 // RunN executes exactly n cycles of measure + stitch within the current generation.
 // Pass n > 0 to override generation.cycles in configuration.yaml for this run only.
-func (Generator) RunN(n int) error { return newOrch().GeneratorRun(n) }
+func (Generator) RunN(n int) error { return newOrch().Generator.GeneratorRun(n) }
 
 // Resume recovers from an interrupted run and continues.
-func (Generator) Resume() error { return newOrch().GeneratorResume() }
+func (Generator) Resume() error { return newOrch().Generator.GeneratorResume() }
 
 // Stop completes a generation trail and merges it into main.
-func (Generator) Stop() error { return newOrch().GeneratorStop() }
+func (Generator) Stop() error { return newOrch().Generator.GeneratorStop() }
 
 // List shows active branches and past generations.
-func (Generator) List() error { return newOrch().GeneratorList() }
+func (Generator) List() error { return newOrch().Generator.GeneratorList() }
 
 // Switch commits current work and checks out another generation branch.
-func (Generator) Switch() error { return newOrch().GeneratorSwitch() }
+func (Generator) Switch() error { return newOrch().Generator.GeneratorSwitch() }
 
 // Reset destroys generation branches, worktrees, and Go source directories.
-func (Generator) Reset() error { return newOrch().GeneratorReset() }
+func (Generator) Reset() error { return newOrch().Generator.GeneratorReset() }
 
 // --- Stats targets ---
 
 // Loc prints Go lines of code and documentation word counts.
-func (Stats) Loc() error { return newOrch().Stats() }
+func (Stats) Loc() error { return newOrch().Stats.PrintStats() }
 
 // Tokens enumerates prompt-attached files and counts tokens via the Anthropic API.
 func (Stats) Tokens() error { return newOrch().TokenStats() }
+
+// Outcomes prints a summary table of task outcome trailers from git history.
+func (Stats) Outcomes() error { return newOrch().Stats.Outcomes() }
+
+// Generator prints a live status report for the current generation run.
+func (Stats) Generator() error { return newOrch().Stats.GeneratorStats() }
+
+// Releases prints a table of roadmap releases with SRD and requirement counts.
+func (Stats) Releases() error { return newOrch().Stats.ReleaseStats() }
+
+// Run prints aggregate statistics for a completed generation run.
+func (Stats) Run(name string) error { return newOrch().Stats.RunStats(name) }
+
+// Compare prints a side-by-side comparison of two generation runs.
+func (Stats) Compare(name1, name2 string) error { return newOrch().Stats.CompareRunStats(name1, name2) }
 
 // --- Prompt targets ---
 
@@ -151,4 +167,3 @@ func (Prompt) Measure() error { return newOrch().DumpMeasurePrompt() }
 
 // Stitch prints the assembled stitch prompt to stdout.
 func (Prompt) Stitch() error { return newOrch().DumpStitchPrompt() }
-


### PR DESCRIPTION
## Summary

Upgrade cobbler-scaffold from v0.20260316.1 to v0.20260403.0, picking up the PRD→SRD rename, interface specification system, new execution articles (E6-E10), implementation_strategy in go-style, and the orchestrator restructuring from god-object to composable domain structs.

## Changes

- Renamed `docs/specs/product-requirements/` → `docs/specs/software-requirements/`, `prd*.yaml` → `srd*.yaml`, and all internal PRD→SRD references across 18 files
- Added `docs/constitutions/interface.yaml` (articles I1-I6) and `docs/engineering/eng10-interface-specifications.yaml`
- Updated `design.yaml` with `interface_specification` document type, `requirement_weight` field, and `generation_run_report` type
- Updated `execution.yaml` with articles E6-E10 (non-goals enforcement, skip ambiguous, function size 40 lines, file size 500 lines, DRY enforcement)
- Updated `go-style.yaml` with `implementation_strategy` section
- Updated `planning.yaml` and prompts from scaffold v0.20260403.0
- Rewrote `magefiles/orchestrator.go` to use component-based API (`Builder`, `Analyzer`, `Releaser`, `Scaffolder`, `Measure`, `Stitch`, `Generator`, `Stats`, `ClaudeRunner`)
- Added new mage targets: `stats:run`, `stats:compare`, `stats:outcomes`, `stats:releases`, `stats:generator`
- Renamed `SPECIFICATIONS.yaml` field names `prd_index` → `srd_index`, `prd_to_use_case_mapping` → `srd_to_use_case_mapping`

## Stats

```
go_loc_prod: 0 (+0)
go_loc_test: 0 (+0)
spec_words:
    srd: 1606
    test_suite: 898
    use_case: 1894
```

## Test plan

- [x] `mage analyze` passes (3 SRDs found, 0 errors, 0 constitution drift)
- [x] `mage -l` lists all targets including new stats targets
- [x] All constitutions match cobbler-scaffold v0.20260403.0

Closes #67