### PR TITLE
Upgrade cobbler-scaffold v0.20260403.0 → v0.20260406.0 (GH-75)

### DIFF
--- a/docs/constitutions/interface.yaml
+++ b/docs/constitutions/interface.yaml
@@ -7,29 +7,28 @@
 
 articles:
   - id: I1
-    title: Interfaces live in ARCHITECTURE.yaml with optional specification files
+    title: Interface specifications live in docs/interfaces/
     rule: |
-      Every interface is declared in the interfaces section of
-      ARCHITECTURE.yaml. An interface groups related data structures and
-      operations under a name that components reference. Interfaces are not
-      declared in SRDs; SRDs reference interfaces defined in the architecture.
+      Every interface has a specification file in docs/interfaces/. The
+      specification file is the authoritative contract: it defines data
+      structures with typed fields and operations with typed parameters and
+      return values. See eng10-interface-specifications for the full format.
 
-      Each interface entry in ARCHITECTURE.yaml may include a spec_file field
-      pointing to a standalone specification file in docs/interfaces/. When
-      spec_file is present, the ARCHITECTURE.yaml entry is a summary and the
-      specification file is the authoritative contract. See
-      eng10-interface-specifications for the full format.
+      ARCHITECTURE.yaml declares each interface in its interfaces section
+      with a name, summary, and a spec_file field pointing to the
+      specification file. The ARCHITECTURE.yaml entry is a discovery point
+      and summary; the specification file is the source of truth.
 
   - id: I2
     title: Required interface fields
     rule: |
-      Every interface entry in ARCHITECTURE.yaml must have a name and a
-      summary. The name is a short, unique identifier (e.g., "Orchestrator
-      and Config", "Prompt Templates"). The summary describes what the
-      interface provides in one to three sentences. Optional fields are
-      data_structures (list of type names with brief descriptions),
-      operations (list of method or function signatures), and spec_file
-      (path to the full specification file).
+      Every interface entry in ARCHITECTURE.yaml must have a name, a
+      summary, and a spec_file. The name is a short, unique identifier
+      (e.g., "Orchestrator and Config", "Prompt Templates"). The summary
+      describes what the interface provides in one to three sentences. The
+      spec_file is the path to the specification file in docs/interfaces/.
+      Optional fields are data_structures (list of type names with brief
+      descriptions) and operations (list of method or function signatures).
 
       Interface specification files in docs/interfaces/ must have id, name,
       and summary. Optional fields are data_structures (with typed field
@@ -69,34 +68,33 @@ articles:
   - id: I5
     title: Port and adapter semantics
     rule: |
-      Interfaces follow the ports and adapters pattern. The interface
-      declaration in ARCHITECTURE.yaml is the port: it defines the
-      contract without specifying implementation. SRDs that list the
-      interface in implemented_by are adapters: they provide a concrete
-      implementation of the port.
+      Interfaces follow the ports and adapters pattern. The specification
+      file in docs/interfaces/ is the port: it defines the contract without
+      specifying implementation. ARCHITECTURE.yaml is the discovery index
+      that points to ports via spec_file. SRDs that list the interface in
+      implemented_by are adapters: they provide a concrete implementation
+      of the port.
 
       This separation means changing an adapter (rewriting a SRD's
-      implementation) does not change the port (the interface definition).
+      implementation) does not change the port (the specification file).
       Consumers that reference the interface via used_by depend on the
       port, not the adapter. Analysis enforces that every referenced
       interface name resolves to a declared port.
 
-      When a specification file exists (spec_file), the port contract is
-      defined in that file using typed field lists for data structures and
-      typed parameter/return lists for operations. The ARCHITECTURE.yaml
-      entry remains the discovery point; the specification file is the
-      contract.
+      The port contract is defined in the specification file using typed
+      field lists for data structures and typed parameter/return lists for
+      operations.
 
   - id: I6
     title: Interface traceability
     rule: |
       The traceability chain for interfaces runs: ARCHITECTURE.yaml
-      (declares the interface) -> specification file in docs/interfaces/
-      (defines the contract) -> SRD implemented_by (provides the
-      implementation) -> SRD used_by (consumes the interface). Analysis
-      validates both directions: every name in implemented_by and used_by
-      must match an interface name in ARCHITECTURE.yaml. Broken references
-      fail the analysis check.
+      (declares the interface with spec_file) -> specification file in
+      docs/interfaces/ (defines the contract) -> SRD implemented_by
+      (provides the implementation) -> SRD used_by (consumes the
+      interface). Analysis validates both directions: every name in
+      implemented_by and used_by must match an interface name in
+      ARCHITECTURE.yaml. Broken references fail the analysis check.
 
       Specification files include a references field listing SRD and use
       case IDs that the interface traces to, completing the bidirectional
@@ -107,20 +105,21 @@ sections:
     title: Core Principles
     content: |
       Six principles govern interface specifications: interfaces live in
-      ARCHITECTURE.yaml with optional specification files in docs/interfaces/
-      (I1), required fields are name and summary with spec_file as optional
-      (I2), names use title case and specification files use kebab case (I3),
-      SRDs reference interfaces via implemented_by and used_by (I4),
-      interfaces follow ports and adapters semantics (I5), and traceability
+      docs/interfaces/ as standalone specification files referenced from
+      ARCHITECTURE.yaml via spec_file (I1), required ARCHITECTURE.yaml
+      fields are name, summary, and spec_file (I2), names use title case
+      and specification files use kebab case (I3), SRDs reference
+      interfaces via implemented_by and used_by (I4), specification files
+      are the ports in ports-and-adapters semantics (I5), and traceability
       runs from architecture through specification files through SRDs (I6).
   - tag: structure
     title: Interface Structure
     content: |
       An interface entry in ARCHITECTURE.yaml is a YAML mapping with five
-      fields: name (required), summary (required), data_structures
-      (optional list), operations (optional list), and spec_file (optional
-      path). SRDs reference interfaces by name using implemented_by and
-      used_by string lists.
+      fields: name (required), summary (required), spec_file (required),
+      data_structures (optional list), and operations (optional list). SRDs
+      reference interfaces by name using implemented_by and used_by string
+      lists.
 
       Specification files in docs/interfaces/ use typed field lists for
       data structures and typed parameter/return lists for operations.
@@ -132,5 +131,5 @@ sections:
       in a SRD's implemented_by and used_by lists must match the name
       field of an interface in ARCHITECTURE.yaml. Unresolved references
       are reported as errors. Missing or empty interface lists are not
-      errors; the fields are optional. When spec_file is present, analyze
-      can validate that the referenced file exists.
+      errors; the fields are optional. Analyze validates that spec_file
+      paths point to existing files.

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260403.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260406.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260403.0 h1:KI+dvlHOGBMluZrt5EjR8GHJFgWYxU5rUNo01+6THTg=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260403.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260406.0 h1:gvqx/AGvq8Q86bvLjdQmYY1KAsvq/AT+m215L0f6KzI=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260406.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades the cobbler-scaffold dependency from v0.20260403.0 to v0.20260406.0, picking up weight management changes (weights moved from SRDs to requirements.yaml), CoT weight-reasoning in the measure prompt, and updated interface constitution (spec_file now required).

## Changes

- Upgraded `cobbler-scaffold` in `magefiles/go.mod` from v0.20260403.0 to v0.20260406.0
- Updated `docs/constitutions/interface.yaml` to match upstream: `spec_file` is now required in ARCHITECTURE.yaml interface entries, specification files are the primary port definition
- Updated `magefiles/go.sum` with new checksums

## Test plan

- [x] `mage analyze` passes with no new errors
- [ ] Documentation reviewed for consistency

Closes #75