### PR TITLE
Release 02.0: Hello World binary from specifications (GH-80)

### DIFF
--- a/cmd/sdd-hello-world/main.go
+++ b/cmd/sdd-hello-world/main.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Command sdd-hello-world prints a fixed greeting and exits.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/cmd/sdd-hello-world/version.go
+++ b/cmd/sdd-hello-world/version.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+// Version is set during the generation process.
+const Version = "0.0.1"


### PR DESCRIPTION
Implements \`rel02.0-uc001-build-hello-world\` from \`srd001-hello-world-binary\`.

## Changes

- \`cmd/sdd-hello-world/main.go\` — entry point, prints \`Hello, World!\` (R1.1, R2.1-R2.3)
- \`cmd/sdd-hello-world/version.go\` — \`Version\` constant, template-compatible (R1.2, R1.3)

## Validation

| Criterion | Result |
|---|---|
| AC1 `go build ./cmd/sdd-hello-world` | exit 0 |
| AC2 stdout / exit code | `Hello, World!\n`, exit 0 |
| AC3 main.go with main function | present |
| AC4 version.go with Version constant | present |
| R1.3 no external dependencies | go.mod clean |

Closes #81
Closes #82

Parent epic: #80