### PR TITLE
Release 02.0: Hello World binary from specifications (GH-85)

### DIFF
--- a/cmd/sdd-hello-world/main.go
+++ b/cmd/sdd-hello-world/main.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Command sdd-hello-world prints a fixed greeting and exits.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/cmd/sdd-hello-world/version.go
+++ b/cmd/sdd-hello-world/version.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+// Version is set during the generation process.
+const Version = "0.0.1"

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -17,7 +17,7 @@ releases:
 
   - version: "02.0"
     name: Hello world binary from specifications
-    status: pending
+    status: done
     description: |
       We implement the hello world binary from its SRD specification. The
       generation pipeline reads srd001-hello-world-binary and produces the Go
@@ -25,7 +25,7 @@ releases:
       code from specs in a clean repository.
     use_cases:
       - id: rel02.0-uc001-build-hello-world
-        status: pending
+        status: done
 
   - version: "03.0"
     name: CLI enhancements


### PR DESCRIPTION
Implements `rel02.0-uc001-build-hello-world` from `srd001-hello-world-binary`.

## Changes

- `cmd/sdd-hello-world/main.go` — entry point, prints `Hello, World!` (R1.1, R2.1-R2.3)
- `cmd/sdd-hello-world/version.go` — `Version` constant, template-compatible (R1.2, R1.3) — implemented via opencode, tool-switch beat
- `docs/road-map.yaml` — release 02.0 and uc001 marked done

## Validation

| Criterion | Result |
|---|---|
| AC1 `go build ./cmd/sdd-hello-world` | exit 0 |
| AC2 stdout / exit code | `Hello, World!\n`, exit 0 |
| AC3 main.go with main function | present |
| AC4 version.go with Version constant | present |
| R1.3 no external dependencies | go.mod clean |

Closes #86
Closes #87

Parent epic: #85