### PR TITLE
GH-92: Release 02.0 — Hello World binary from specifications

### DIFF
--- a/cmd/sdd-hello-world/main.go
+++ b/cmd/sdd-hello-world/main.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import "fmt"
+
+// main writes the greeting to stdout and returns, exiting with code 0.
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/cmd/sdd-hello-world/version.go
+++ b/cmd/sdd-hello-world/version.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+// Version is set during the generation process.
+const Version = "v0.20260406.0"

--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -142,7 +142,7 @@ project_structure:
     role: Go module definition (no external dependencies)
 
 implementation_status:
-  current_focus: Release 02.0 — implement binary from specifications
+  current_focus: Release 03.0 — CLI enhancements (--version, --name, --help, error handling)
   progress:
     - done: Scaffolded mage targets (magefiles/orchestrator.go)
     - done: Configuration (configuration.yaml)
@@ -151,7 +151,9 @@ implementation_status:
     - done: SRD, use case, and test suite for hello world binary (rel02.0)
     - done: SRD, use cases, and test suite for CLI enhancements (rel03.0)
     - done: SRD, use cases, and test suite for config file support (rel04.0)
-    - pending: Go binary (cmd/sdd-hello-world/main.go, cmd/sdd-hello-world/version.go)
+    - done: Go binary greeting and version constant (cmd/sdd-hello-world/main.go, cmd/sdd-hello-world/version.go)
+    - pending: CLI flag parsing --version, --name, --help (rel03.0)
+    - pending: Config file loading via --config (rel04.0)
 
 related_documents:
   - doc: docs/VISION.yaml

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -17,7 +17,7 @@ releases:
 
   - version: "02.0"
     name: Hello world binary from specifications
-    status: pending
+    status: done
     description: |
       We implement the hello world binary from its SRD specification. The
       generation pipeline reads srd001-hello-world-binary and produces the Go
@@ -25,7 +25,7 @@ releases:
       code from specs in a clean repository.
     use_cases:
       - id: rel02.0-uc001-build-hello-world
-        status: pending
+        status: done
 
   - version: "03.0"
     name: CLI enhancements


### PR DESCRIPTION
## Summary

Implements release 02.0 from `srd001-hello-world-binary`: the two Go source
files that make up the hello world binary. The binary prints `Hello, World!`
to stdout and exits 0, using the standard library only. Release 02.0 and
`rel02.0-uc001-build-hello-world` are marked done.

## Changes

- `cmd/sdd-hello-world/main.go` — `main` function printing the greeting (R1.1, R2.1-R2.3)
- `cmd/sdd-hello-world/version.go` — package-level `Version` constant, matching the shape of `magefiles/version.go.tmpl` so a later `mage generator:start` regenerates it without conflict (R1.2, R1.3)
- `docs/road-map.yaml` — release 02.0 and uc001 `pending` -> `done`
- `docs/ARCHITECTURE.yaml` — `current_focus` advanced to release 03.0; `implementation_status.progress` records the binary as done and lists the rel03.0/rel04.0 work as pending

`go.mod` is unchanged and still declares zero external dependencies.

## Stats

| Metric | Before | After | Delta |
|---|---|---|---|
| Lines of code (Go, production) | 0 | 18 | +18 |
| Lines of code (Go, tests) | 0 | 0 | 0 |
| Words (documentation) | 4398 | 4398 | 0 |

Estimated vs Actual LOC: #93 estimated ~12, actual 11. #94 estimated ~7,
actual 7. Epic estimated ~25, actual 18.

`mage stats:releases` reports release 02.0 at 6/6 requirements done.

## Test plan

- `mage analyze` — all consistency checks pass (3 SRDs, 5 use cases, 3 test suites). Remaining warnings concern srd003 AC coverage and untraced S-items in rel03.0/rel04.0, both pre-existing and out of scope here.
- `go vet ./cmd/sdd-hello-world` — clean.
- `go test ./...` — no test files, per the SRD non-goal "writing tests within this project".
- Test suite `test-rel02.0` executed by hand, all five cases:
  - Build succeeds — `go build ./cmd/sdd-hello-world` exits 0
  - Binary prints greeting — stdout hex-dumped as `4865 6c6c 6f2c 2057 6f72 6c64 210a`, exactly `Hello, World!\n`, 14 bytes, stderr 0 bytes
  - Binary exits with code 0 — confirmed
  - Version constant exists — `const Version` declared in `version.go`
  - No external dependencies — `go.mod` has 0 `require` directives

Epic acceptance criteria AC1-AC4 all verified as behaviour.

Closes #92
Closes #93
Closes #94
