### PR TITLE
README: fork-first setup and coding-skills symlink instructions (GH-102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,130 @@
 # sdd-hello-world
 
-Minimal SDD test fixture for cobbler-scaffold.
+A minimal specification-driven Go project, small enough to read on a
+projector and real enough to run a full agent loop against. It is the demo
+repository for the talk
+[The Human Is the Loop](talks/2026-08-11-human-is-the-loop/), and the test
+fixture cobbler-scaffold scaffolds against in its end-to-end suite.
 
-## Architectural Thesis
+The specifications come first. There is no `cmd/` tree at rest — the binary
+is what the loop generates from `docs/specs/` when you run the demo.
 
-Cobbler-scaffold end-to-end tests need a stable, minimal Go project to scaffold against. Using a production SDD project couples test stability to ongoing development. This repository provides the simplest possible Go binary wrapped in the SDD project structure, isolating cobbler-scaffold validation from production project changes.
+## Try the demo yourself
 
-## Scope and Status
+### 1. Fork it
 
-The project is complete. It consists of a single Go binary that prints "Hello, World!" and a VISION specification document. The cobbler-scaffold orchestrator scaffolds this project and runs mage targets against it during e2e testing.
+**Fork this repository to your own account first.** The demo files issues,
+pushes branches, opens and merges pull requests, and closes issues. All of
+that needs write access, and you have none here. Working against this
+account, `/gh-issue-push` fails at the first step.
 
-## Repository Structure
+```bash
+gh repo fork petar-djukic/sdd-hello-world --clone
+```
+
+Or fork on the GitHub website, then clone your fork.
+
+### 2. Clone coding-skills beside it
+
+The four commands the demo runs do not live in this repository. `.claude`
+and `.opencode` are **relative symlinks** to `../coding-skills/`, so
+[coding-skills](https://github.com/petar-djukic/coding-skills) has to sit in
+the same parent directory as your clone:
+
+```bash
+cd ..                                                        # the parent of your clone
+git clone https://github.com/petar-djukic/coding-skills.git
+```
+
+You should end up with the two side by side:
+
+```
+~/GITHUB/
+  sdd-hello-world/     <- your fork
+    .claude    -> ../coding-skills/.claude
+    .opencode  -> ../coding-skills/.opencode
+  coding-skills/       <- the commands
+```
+
+### 3. Check that the commands resolved
+
+```bash
+cd sdd-hello-world
+ls .claude/commands/
+```
+
+You should see `make-work.md`, `gh-issue-push.md`, `gh-issue-pop.md`, and
+`do-work.md` among others. An empty listing or "No such file or directory"
+means the symlink is dangling — `coding-skills` is not where the link
+expects it.
+
+If you cloned `coding-skills` somewhere else and would rather not move it,
+repoint the links locally:
+
+```bash
+ln -sfn /path/to/coding-skills/.claude   .claude
+ln -sfn /path/to/coding-skills/.opencode .opencode
+```
+
+Leave that change out of your commits — the tracked links are relative on
+purpose.
+
+### 4. Run the loop
+
+Open Claude Code (or opencode) in the repository and work the cycle:
+
+| Command | What it does |
+|---|---|
+| `/make-work` | reads the specs, verifies the tracker, proposes a batch — you approve |
+| `/gh-issue-push` | writes the approved plan as self-contained GitHub issues |
+| `/gh-issue-pop <n>` | decomposes an issue into sub-issues on its own git worktree |
+| `/do-work` | implements one sub-issue, validates it, commits, opens the PR |
+
+You merge the PR. The agent never merges its own.
+
+Scope `/make-work` when you run it, or it will propose from the whole
+roadmap. For the same batch the talk demos:
+
+```
+/make-work
+scope it to release 02.0: one epic, and two issues under it,
+one per source file. Nothing else.
+```
+
+The beat-by-beat runbook, including the reset that returns the repository to
+a clean slate afterwards, is in
+[talks/2026-08-11-human-is-the-loop/DEMO-PLAN.md](talks/2026-08-11-human-is-the-loop/DEMO-PLAN.md).
+
+## Why the repository is built this way
+
+Cobbler-scaffold's end-to-end tests need a stable, minimal Go project to
+scaffold against. Pointing them at a production SDD project couples test
+stability to ongoing development. This repository is the simplest possible
+Go binary wrapped in the full SDD structure, which isolates that validation
+from production changes — and makes the whole loop visible in one screen.
+
+## Repository structure
 
 ```
 sdd-hello-world/
-  cmd/sdd-hello-world/main.go   -- Hello World binary
-  docs/VISION.yaml               -- SDD vision specification
-  docs/constitutions/             -- Scaffolded design constitutions
-  docs/prompts/                   -- Scaffolded prompt templates
-  magefiles/orchestrator.go       -- Cobbler-scaffold mage targets
-  configuration.yaml              -- Orchestrator configuration
+  docs/VISION.yaml            -- goals and boundaries
+  docs/ARCHITECTURE.yaml      -- components
+  docs/road-map.yaml          -- releases and their use cases
+  docs/specs/                 -- SRDs, use cases, test suites
+  docs/constitutions/         -- design, testing, interface rules the agent obeys
+  docs/prompts/               -- scaffolded prompt templates
+  magefiles/orchestrator.go   -- cobbler-scaffold mage targets
+  configuration.yaml          -- orchestrator configuration
+  talks/                      -- The Human Is the Loop: deck and demo runbook
+  .claude, .opencode          -- symlinks to ../coding-skills (see above)
 ```
 
-## Build and Test
+`cmd/sdd-hello-world/` appears once release 02.0 is implemented, and the
+demo reset removes it again.
+
+## Build and test
+
+Only after the binary has been generated:
 
 ```bash
 go build -o bin/sdd-hello-world ./cmd/sdd-hello-world
@@ -37,3 +139,11 @@ mage build
 mage init
 mage -l
 ```
+
+## The talk
+
+`talks/2026-08-11-human-is-the-loop/` holds the slides, the demo runbook,
+and the prompt cards used on stage. Its
+[README](talks/2026-08-11-human-is-the-loop/README.md) covers serving the
+deck. Every skill has a write-up at
+[meshintelligence.substack.com](https://meshintelligence.substack.com).


### PR DESCRIPTION
Post-meetup follow-up so people can run the loop on their own machines.

## Two blockers this removes

1. **No write access on this account.** The demo files issues, pushes branches, opens and merges PRs. The README now says *fork first*, before any clone command, with the reason.
2. **The commands are not in this repo.** `.claude` and `.opencode` are relative symlinks to `../coding-skills/`. A fresh clone leaves them dangling unless `coding-skills` is a sibling directory — now documented, with a layout diagram, a verification step, and a recovery path for a non-sibling clone.

## Also corrected

The README claimed `cmd/sdd-hello-world/main.go` exists and the project was "complete", while `docs/road-map.yaml` has release 02.0 pending. At clean slate there is no `cmd/` tree — the binary is what the loop generates. Repository Structure now lists only files that exist, and notes that `cmd/` appears when release 02.0 is implemented and disappears at reset.

## Verification

Cloned both repositories fresh into a temp directory and followed the README literally:

| Check | Result |
|---|---|
| Documented clone path, symlinks resolve | all 14 commands listed, including `make-work.md` |
| `coding-skills` moved out of sibling position | reproduces the exact documented error |
| Recovery `ln -sfn` commands | commands resolve again |
| Repoint shows as a git modification | confirms the "leave it out of your commits" note |

Every relative link and external URL in the README checked.

Closes #102