### PR TITLE
SEO: make the repository discoverable (GH-104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # sdd-hello-world
 
-A minimal specification-driven Go project, small enough to read on a
-projector and real enough to run a full agent loop against. It is the demo
-repository for the talk
+A working example of spec-driven development with a coding agent, small
+enough to read on a projector. Four slash commands drive the whole cycle in
+Claude Code or opencode: GitHub issues carry the memory between sessions,
+each task gets its own git worktree, and a pull request you review closes the
+loop. It is the demo repository for the talk
 [The Human Is the Loop](talks/2026-08-11-human-is-the-loop/), and the test
 fixture cobbler-scaffold scaffolds against in its end-to-end suite.
 
-The specifications come first. There is no `cmd/` tree at rest — the binary
-is what the loop generates from `docs/specs/` when you run the demo.
+The specifications come first. There is no `cmd/` tree at rest — the Go
+binary is what the agent generates from `docs/specs/` when you run the demo.
 
 ## Try the demo yourself
 
@@ -95,7 +97,7 @@ The beat-by-beat runbook, including the reset that returns the repository to
 a clean slate afterwards, is in
 [talks/2026-08-11-human-is-the-loop/DEMO-PLAN.md](talks/2026-08-11-human-is-the-loop/DEMO-PLAN.md).
 
-## Why the repository is built this way
+## Why spec-driven development needs a fixture like this
 
 Cobbler-scaffold's end-to-end tests need a stable, minimal Go project to
 scaffold against. Pointing them at a production SDD project couples test


### PR DESCRIPTION
Post-meetup the repo is being shared but is effectively invisible to search. Three levers, all unused or working against it.

## What changed

**Description** (applied with `gh repo edit`, not a file):

> before: `Minimal SDD test fixture for cobbler-scaffold`
> after: `Spec-driven development with a coding agent: four slash commands for Claude Code and opencode, GitHub issues as memory, a git worktree per task. Demo repo for the talk The Human Is the Loop.`

`SDD` is an unexplained acronym and `cobbler-scaffold` is a tool nobody outside these repos searches for — the old description matched no query a person would type, and it doubles as the Google result snippet.

**Topics**: were `null`. Now cover the agents, the method, the mechanics, and the language.

**Homepage**: set to the blog where the write-ups live.

**README opening**: named the four mechanics — Claude Code / opencode, GitHub issues as memory, git worktree per task, the PR gate — as prose. One heading rephrased toward the query it answers.

## Constraint held

No keyword stuffing. Every term is one the repository can credibly answer for; a reader arriving on any of these queries finds what they came for. Nothing asserted that the repo does not demonstrate.

Closes #104