### PR TITLE
GH-106: README backlinks: link each demonstrated skill to its article write-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # sdd-hello-world
 
-A working example of spec-driven development with a coding agent, small
-enough to read on a projector. Four slash commands drive the whole cycle in
-Claude Code or opencode: GitHub issues carry the memory between sessions,
-each task gets its own git worktree, and a pull request you review closes the
-loop. It is the demo repository for the talk
+A working example of
+[spec-driven development with a coding agent](https://meshintelligence.substack.com/p/spec-driven-development-with-github?utm_source=github&utm_campaign=sdd-hello-world),
+small enough to read on a projector. Four slash commands drive the whole
+cycle in Claude Code or
+[opencode](https://meshintelligence.substack.com/p/how-to-glm-52-on-opencode?utm_source=github&utm_campaign=sdd-hello-world):
+[GitHub issues carry the memory between sessions](https://meshintelligence.substack.com/p/how-to-use-github-as-long-term-memory?utm_source=github&utm_campaign=sdd-hello-world),
+[each task gets its own git worktree](https://meshintelligence.substack.com/p/how-to-use-git-worktrees-with-coding?utm_source=github&utm_campaign=sdd-hello-world),
+and a pull request you review closes the loop. It is the demo repository for
+the talk
 [The Human Is the Loop](talks/2026-08-11-human-is-the-loop/), and the test
 fixture cobbler-scaffold scaffolds against in its end-to-end suite.
 
@@ -73,7 +77,8 @@ purpose.
 
 ### 4. Run the loop
 
-Open Claude Code (or opencode) in the repository and work the cycle:
+Open Claude Code (or opencode) in the repository and
+[work the cycle](https://meshintelligence.substack.com/p/how-to-loop-engineering?utm_source=github&utm_campaign=sdd-hello-world):
 
 | Command | What it does |
 |---|---|
@@ -93,8 +98,9 @@ scope it to release 02.0: one epic, and two issues under it,
 one per source file. Nothing else.
 ```
 
-The beat-by-beat runbook, including the reset that returns the repository to
-a clean slate afterwards, is in
+The beat-by-beat runbook, including the
+[recurring issue](https://meshintelligence.substack.com/p/how-to-use-github-to-give-a-coding?utm_source=github&utm_campaign=sdd-hello-world)
+that returns the repository to a clean slate afterwards, is in
 [talks/2026-08-11-human-is-the-loop/DEMO-PLAN.md](talks/2026-08-11-human-is-the-loop/DEMO-PLAN.md).
 
 ## Why spec-driven development needs a fixture like this
@@ -147,5 +153,14 @@ mage -l
 `talks/2026-08-11-human-is-the-loop/` holds the slides, the demo runbook,
 and the prompt cards used on stage. Its
 [README](talks/2026-08-11-human-is-the-loop/README.md) covers serving the
-deck. Every skill has a write-up at
-[meshintelligence.substack.com](https://meshintelligence.substack.com).
+deck. Every skill the talk demos has a write-up on
+[meshintelligence.substack.com](https://meshintelligence.substack.com?utm_source=github&utm_campaign=sdd-hello-world):
+
+| Write-up | What it covers |
+|---|---|
+| [How to Loop Engineering](https://meshintelligence.substack.com/p/how-to-loop-engineering?utm_source=github&utm_campaign=sdd-hello-world) | getting the model to write its own prompts |
+| [How to Use GitHub as Long-Term Memory for Coding Agents](https://meshintelligence.substack.com/p/how-to-use-github-as-long-term-memory?utm_source=github&utm_campaign=sdd-hello-world) | issues as the memory between sessions |
+| [How to Use Git Worktrees with Coding Agents](https://meshintelligence.substack.com/p/how-to-use-git-worktrees-with-coding?utm_source=github&utm_campaign=sdd-hello-world) | one workspace per task |
+| [How to Use GitHub to Give a Coding Agent Recurring Work](https://meshintelligence.substack.com/p/how-to-use-github-to-give-a-coding?utm_source=github&utm_campaign=sdd-hello-world) | recurring issues and temporal agency |
+| [How to Code with GLM 5.2 on OpenCode](https://meshintelligence.substack.com/p/how-to-glm-52-on-opencode?utm_source=github&utm_campaign=sdd-hello-world) | the second tool the demo hands the same issue to |
+| [Spec-Driven Development with GitHub, Claude, and GLM on OpenCode](https://meshintelligence.substack.com/p/spec-driven-development-with-github?utm_source=github&utm_campaign=sdd-hello-world) | the whole cycle, demonstrated on this repository |

--- a/talks/2026-08-11-human-is-the-loop/README.md
+++ b/talks/2026-08-11-human-is-the-loop/README.md
@@ -62,3 +62,16 @@ there; alt-tab never leaves the browser.
 The four prompt cards mirror the live slides one to one — what is on screen
 is what gets typed. Beat-by-beat flow, timings, and failure insurance:
 [DEMO-PLAN.md](DEMO-PLAN.md).
+
+## Write-ups
+
+Each of the four skills on stage has a longer written treatment:
+[How to Loop Engineering](https://meshintelligence.substack.com/p/how-to-loop-engineering?utm_source=github&utm_campaign=sdd-hello-world),
+[How to Use GitHub as Long-Term Memory for Coding Agents](https://meshintelligence.substack.com/p/how-to-use-github-as-long-term-memory?utm_source=github&utm_campaign=sdd-hello-world),
+[How to Use Git Worktrees with Coding Agents](https://meshintelligence.substack.com/p/how-to-use-git-worktrees-with-coding?utm_source=github&utm_campaign=sdd-hello-world),
+and
+[How to Use GitHub to Give a Coding Agent Recurring Work](https://meshintelligence.substack.com/p/how-to-use-github-to-give-a-coding?utm_source=github&utm_campaign=sdd-hello-world).
+The talk itself is written up as
+[Spec-Driven Development with GitHub, Claude, and GLM on OpenCode](https://meshintelligence.substack.com/p/spec-driven-development-with-github?utm_source=github&utm_campaign=sdd-hello-world),
+and the tool switch in Skill 3 as
+[How to Code with GLM 5.2 on OpenCode](https://meshintelligence.substack.com/p/how-to-glm-52-on-opencode?utm_source=github&utm_campaign=sdd-hello-world).


### PR DESCRIPTION
## Summary

The README's only pointer to the write-ups was one generic homepage link, and the per-article links lived only in the `.slide` file, which GitHub serves as plain text with no crawlable anchors. This replaces the generic pointer with descriptive, utm-tagged links at each concept's first mention and adds a Write-ups section to the talk README, so both crawlable pages carry keyworded backlinks.

## Changes

- README.md intro: `spec-driven development with a coding agent`, `opencode`, `GitHub issues carry the memory between sessions`, and `each task gets its own git worktree` now link their articles at first mention.
- README.md step 4: `work the cycle` links How to Loop Engineering; the demo-reset sentence links the recurring-work article.
- README.md "The talk": the bare homepage link becomes a six-row write-up table with article-title anchors.
- talks/2026-08-11-human-is-the-loop/README.md: new Write-ups section linking the four skill articles plus the talk and tool-switch write-ups.
- `human-is-the-loop.slide` untouched — it is a stage artifact, not a link surface.

## Stats

    Lines of code (Go, production): 0 (+0)
    Lines of code (Go, tests):      0 (+0)
    Documentation:                  38 added, 10 removed across 2 files

Estimated LOC: ~15 changed lines across 2 files. Actual: 38 added / 10 removed.

## Test plan

- `mage analyze` passes (3 SRDs, 5 use cases, 3 test suites).
- All 19 meshintelligence links carry `utm_source=github&utm_campaign=sdd-hello-world` (grep for untagged returns nothing).
- All seven distinct article URLs return HTTP 200.
- `git status` confirms only the two README files changed.

Closes #106