### PR TITLE
GH-108: link the live talk page (GitHub Pages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ mage -l
 
 ## The talk
 
+The talk page lives at
+[petar-djukic.github.io/sdd-hello-world](https://petar-djukic.github.io/sdd-hello-world/).
 `talks/2026-08-11-human-is-the-loop/` holds the slides, the demo runbook,
 and the prompt cards used on stage. Its
 [README](talks/2026-08-11-human-is-the-loop/README.md) covers serving the

--- a/talks/2026-08-11-human-is-the-loop/README.md
+++ b/talks/2026-08-11-human-is-the-loop/README.md
@@ -1,7 +1,10 @@
 # The Human Is the Loop
 
 Slides and demo runbook for the 2026-08-11 Ottawa ML/AI meetup talk.
-The talk demos this repository live.
+The talk demos this repository live. The public talk page, with the
+write-up links, is at
+[petar-djukic.github.io/sdd-hello-world](https://petar-djukic.github.io/sdd-hello-world/)
+(served from the `gh-pages` branch).
 
 ## Serve the deck
 


### PR DESCRIPTION
## Summary

Links the now-live talk page (https://petar-djukic.github.io/sdd-hello-world/) from the main and talk READMEs. The site itself is on the orphan gh-pages branch (index.html + 5 deck figures), Pages enabled from its root — a followable-link surface, unlike rendered READMEs.

## Changes

- README.md: talk section links the live page
- talks/2026-08-11-human-is-the-loop/README.md: live-page pointer

## Stats

+6/-1, 2 files (plus 6 files / 2220 lines on gh-pages, mostly copied SVGs).

## Test plan

- Site returns 200; page HTML contains 0 rel=nofollow; spot-checked article hrefs carry the ghpages utm tag

Closes #108